### PR TITLE
TLS using a hardware security module

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -207,16 +207,21 @@ static string _spawn(const string& cmd_line)
 {
 	g_autofree GError *error = nullptr;
 	g_autofree gchar *stdout_buff = nullptr;
+	g_autofree gchar *stderr_buff = nullptr;
 	gint status;
 
-	if(!g_spawn_command_line_sync(cmd_line.c_str(), &stdout_buff, NULL, &status, &error)) {
+	if (!g_spawn_command_line_sync(cmd_line.c_str(), &stdout_buff, &stderr_buff, &status, &error)) {
 		cerr << "Unable to run: " << cmd_line << endl;
 		cerr << "Error is: " << error->message << endl;
 		exit(EXIT_FAILURE);
 	}
-	if(error) {
+	if (status) {
 		cerr << "Unable to run: " << cmd_line << endl;
-		cerr << "STDERR is: " << stderr << endl;
+		cerr << "STDERR is: " << stderr_buff << endl;
+		exit(EXIT_FAILURE);
+	}
+	if (error) {
+		cerr << "Unable to run: " << cmd_line << endl;
 		exit(EXIT_FAILURE);
 	}
 	return stdout_buff;


### PR DESCRIPTION
@doanac this is enough to get aktualizr at least connecting to the OTA Server on my machine with a suitably configured softhsm. (I'm seeing a "could not put manifest" error though that I think might have to do with an Uptane key).

You can see the FIXME comments in the PR for where I just hack through things. What I think we ought to do to fix them is support an "overrides" parameter in the ota_api's /devices/ POST.

The value of "overrides" would be a dict, mapping keys which are `sota_toml_section.key` to values which are the corresponding values.

So for example:

```
overrides = {
    'storage.path': '"/var/not-sota"',
    'tls.ca_source': '"pkcs11"',
}
```

Would result in a sota.toml with those overrides applied to the default, like so:

```
[storage]
path = "/var/not-sota"
...

[tls]
ca_source = "pkcs11"
```

That would allow something like the following cleanup to this PR:

```
diff --git a/src/main.cpp b/src/main.cpp
index fb0983f..327c7d1 100644
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -485,10 +485,16 @@ int main(int argc, char **argv)
        headers["Authorization"] = "Bearer " + boost::beast::detail::base64_encode(token);
 
        ptree device;
+       ptree overrides;
        device.put("name", name);
        device.put("uuid", final_uuid);
        device.put("csr", csr);
-       device.put("hardware-id", hwid); // FIXME overrides for key/ca source when API supports it; needs manual sota.toml massaging until then
+       device.put("hardware-id", hwid);
+       overrides.put("tls.pkey_source", "\"pkcs11\"");
+       overrides.put("tls.cert_source", "\"pkcs11\"");
+       overrides.put("storage.tls_pkey_path", nullptr);
+       overrides.put("storage.tls_clientcert_path", nullptr);
+       device.put("overrides", overrides);
        stringstream data;
        write_json(data, device);
 
@@ -530,26 +536,13 @@ int main(int argc, char **argv)
 
                out.close();
 
-               if (!hsm_module.empty()) {
-                       if (ends_with(name, ".toml")) {
-                               // HACK:
-                               // Post-process the SOTA TOML to fix up some values for PKCS#11.
-                               // Keep a copy of the original (with the extra PKCS11 stuff added in for debugging).
-                               // FIXME: remove this once we've got overrides in place.
-                               string bak = name + ".bak";
-                               _spawn("cp " + name + " " + bak);
-                               _spawn("sed -i 's/pkey_source =.*/pkey_source = \"pkcs11\"/' " + name);
-                               _spawn("sed -i 's/cert_source =.*/cert_source = \"pkcs11\"/' " + name);
-                               _spawn("sed -i 's/.*tls_pkey_path =.*/# tls_pkey_path is not set/' " + name);
-                               _spawn("sed -i 's/.*tls_clientcert_path =.*/# tls_clientcert_path is not set/' " + name);
-                       } else if (ends_with(name, ".pem")) {
-                               // The client cert is stored in the HSM. The copy in /var/sota
-                               // is just a "courtesy".
-                               TempDir tmp_dir;
-                               string client_der = tmp_dir.GetPath() + "/client.der";
-                               _spawn("openssl x509 -inform pem -in " + name + " -out " + client_der);
-                               _pkcs11_tool(hsm_module, "-w " + client_der + " -y cert --id " + hsm_client_cert_id, hsm_pin);
-                       }
+               if (!hsm_module.empty() && ends_with(name, ".pem")) {
+                       // The client cert is stored in the HSM. The copy in /var/sota
+                       // is just a "courtesy".
+                       TempDir tmp_dir;
+                       string client_der = tmp_dir.GetPath() + "/client.der";
+                       _spawn("openssl x509 -inform pem -in " + name + " -out " + client_der);
+                       _pkcs11_tool(hsm_module, "-w " + client_der + " -y cert --id " + hsm_client_cert_id, hsm_pin);
                }
        }
        cout << "Device is now registered." << endl;
```

Tested on qemu-riscv64 using LMP build 527.