### PR TITLE
Drop base64_encode, removed in boost 1.71

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -504,10 +504,13 @@ int main(int argc, char **argv)
 	}
 
 	string token = _get_oauth_token(final_uuid);
+	string token_base64;
+	token_base64.resize(boost::beast::detail::base64::encoded_size(token.size()));
+	boost::beast::detail::base64::encode(&token_base64[0], token.data(), token.size());
 
 	http_headers headers;
 	headers["Content-type"] = "application/json";
-	headers["Authorization"] = "Bearer " + boost::beast::detail::base64_encode(token);
+	headers["Authorization"] = "Bearer " + token_base64;
 
 	ptree device;
 	device.put("name", name);


### PR DESCRIPTION
Use the base functions used by base64_encode in order to be compatible
with boost 1.69 and 1.71, as base64_encode was removed from boost 1.71.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>