### PR TITLE
Fix probing of hwid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ if(DOCKER_APPS)
     message(STATUS "Enabling docker-apps support")
 endif(DOCKER_APPS)
 
+IF (NOT DEFINED HARDWARE_ID)
+    message(FATAL_ERROR "Missing required value: HARDWARE_ID")
+ENDIF()
+ADD_DEFINITIONS(-DHARDWARE_ID="${HARDWARE_ID}")
+message(STATUS "Setting HARDWARE_ID to ${HARDWARE_ID}")
 
 IF (NOT DEFINED DEVICE_STREAMS)
     SET(DEVICE_STREAMS "release,premerge")


### PR DESCRIPTION
We already know the value of the platform when this is built. OE
has it defined as "MACHINE", so this can just be set at build time
to eliminate the need to provide this value.

Signed-off-by: Andy Doan <andy@foundries.io>