### PR TITLE
Supply a default tag if found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ option(AKLITE_TAGS "Set to ON to compile with support of aktualizr-lite tag filt
 if(AKLITE_TAGS)
     add_definitions(-DAKLITE_TAGS)
     message(STATUS "Enabling aktualir-lite tag support")
+
+    if (DEFINED DEFAULT_TAG)
+        add_definitions(-DDEFAULT_TAG="${DEFAULT_TAG}")
+        message(STATUS "Setting DEFAULT_TAG to ${DEFAULT_TAG}")
+    endif (DEFINED DEFAULT_TAG)
 endif(AKLITE_TAGS)
 
 option(DOCKER_APPS "Set to ON to compile with support for configuring docker-apps" OFF)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,8 +80,13 @@ static bool _get_options(int argc, char **argv, Options &options)
 		("stream,s", po::value<string>(&options.stream)->default_value(streams[0]),
 		 "The update stream to subscribe to: " DEVICE_STREAMS)
 #ifdef AKLITE_TAGS
+#ifdef DEFAULT_TAG
+		("tags,t", po::value<string>(&options.pacman_tags)->default_value(DEFAULT_TAG),
+		 "Configure aktualizr-lite to only apply updates from Targets with these tags. Default is " DEFAULT_TAG)
+#else
 		("tags,t", po::value<string>(&options.pacman_tags),
 		 "Configure aktualizr-lite to only apply updates from Targets with these tags.")
+#endif
 #endif
 #ifdef DOCKER_APPS
 		("docker-apps,a", po::value<string>(&options.docker_apps),


### PR DESCRIPTION
If users are building factories with tags defined, its reasonable to
assume that this resulting lmp-device-register should default to
subscribing to targets with the this same tag.

Signed-off-by: Andy Doan <andy@foundries.io>