### PR TITLE
Add an api-token-header argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@ typedef std::map<std::string, string> http_headers;
 
 struct Options {
 	string api_token;
+	string api_token_header;
 	string factory;
 	string hwid;
 	string uuid;
@@ -124,7 +125,10 @@ static bool _get_options(int argc, char **argv, Options &options)
 		 "The name of the device as it should appear in the dashboard. If not specified, it will use the device's UUID")
 
 		("api-token,T", po::value<string>(&options.api_token),
-		 "Use a foundries.io API token for authentication. If not specified, oauth2 will be used")
+		 "Use an API token for authentication. If not specified, oauth2 will be used")
+
+		("api-token-header,H", po::value<string>(&options.api_token_header)->default_value("OSF-TOKEN"),
+		 "Specify a HTTP header to be used for authentication. Defaults to \"OSF-TOKEN\".")
 
 		("start-daemon", po::value<bool>(&options.start_daemon)->default_value(true),
 		 "Start the aktualizr-lite systemd service automatically after performing the registration.")
@@ -567,7 +571,7 @@ int main(int argc, char **argv)
 	headers["Content-type"] = "application/json";
 
 	if (!options.api_token.empty()) {
-		headers["OSF-TOKEN"] = options.api_token;
+		headers[options.api_token_header] = options.api_token;
 	} else {
 		string token = _get_oauth_token(options.factory, final_uuid);
 		string token_base64;


### PR DESCRIPTION
## Summary
In order to generalize the API hit by the `lmp-device-register` command, I've added a `-H`/`--api-token-header` CLI option that allows users to specify the exact authorization header they need.

I'd expect the command to be called something like:

```sh
./lmp-device-register -f ${FACTORY} -T ${JWT_TOKEN} -H Authorization -r https://${API_GATEWAY}/sign -n ${DEVICE_NAME}
```

The specific use case is ensuring that we can use a general-purpose `Authorization` header for a [AWS Cognito-based authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-invoke-api-integrated-with-cognito-user-pool.html). 

## Extra notes
* Seemed out of scope to generalize and provide variadic header arguments
* I kept the `OSF-TOKEN` as a default header to not have breaking changes
* Haven't compiled and run this on a robot. Seems like there's a dependency on `libboost >= 1.66` and Ubuntu 18.04's latest `apt-get`able is 1.65. Wanted to get this out before getting into the weeds of dependency management.