### PR TITLE
Remove DEFAULT_TAG, AKLITE_TAGS and DEVICE_FACTORY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,6 @@ cmake_minimum_required (VERSION 3.5)
 
 project(lmp-device-register)
 
-option(AKLITE_TAGS "Set to ON to compile with support of aktualizr-lite tag filtering" OFF)
-if(AKLITE_TAGS)
-    add_definitions(-DAKLITE_TAGS)
-    message(STATUS "Enabling aktualir-lite tag support")
-
-    if (DEFINED DEFAULT_TAG)
-        add_definitions(-DDEFAULT_TAG="${DEFAULT_TAG}")
-        message(STATUS "Setting DEFAULT_TAG to ${DEFAULT_TAG}")
-    endif (DEFINED DEFAULT_TAG)
-endif(AKLITE_TAGS)
-
 option(DOCKER_COMPOSE_APP "Set to ON to compile with support for configuring compose-apps" OFF)
 
 if(DOCKER_COMPOSE_APP)
@@ -35,16 +24,6 @@ IF (NOT DEFINED HARDWARE_ID)
 ENDIF()
 ADD_DEFINITIONS(-DHARDWARE_ID="${HARDWARE_ID}")
 message(STATUS "Setting HARDWARE_ID to ${HARDWARE_ID}")
-
-IF (NOT DEFINED DEVICE_FACTORY)
-    IF(NOT DEFINED DEVICE_STREAMS)
-        message(FATAL_ERROR "Missing required value: DEVICE_FACTORY or DEVICE_STREAMS")
-    ENDIF()
-    message(STATUS "Using DEVICE_STREAMS as DEVICE_FACTORY value (${DEVICE_STREAMS})")
-    SET(DEVICE_FACTORY ${DEVICE_STREAMS})
-ENDIF()
-ADD_DEFINITIONS(-DDEVICE_FACTORY="${DEVICE_FACTORY}")
-message(STATUS "Setting DEVICE_FACTORY to ${DEVICE_FACTORY}")
 
 IF (NOT DEFINED DEVICE_API)
     SET(DEVICE_API "https://api.foundries.io/ota/devices/")

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -2,4 +2,4 @@
 
 cd $(dirname $(readlink -f $0))
 
-clang-tidy-6.0 ./src/main.cpp -- $(pkg-config --cflags glib-2.0) -DDEVICE_FACTORY='"foo"' -DDEVICE_API='"url"' -DDOCKER_COMPOSE_APP="1" -DAKLITE_TAGS="1" -DHARDWARE_ID='"foo"' -DGIT_COMMIT='"deadbeef"'
+clang-tidy-6.0 ./src/main.cpp -- $(pkg-config --cflags glib-2.0) -DDEVICE_API='"url"' -DDOCKER_COMPOSE_APP="1" -DHARDWARE_ID='"foo"' -DGIT_COMMIT='"deadbeef"'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -40,6 +41,7 @@ static const string hsm_tls_key_id = "01";           // TLS key ID on HSM, when 
 static const string hsm_client_cert_id = "03";       // Client certificate's ID on HSM, when used (for sota.toml)
 static const string hsm_tls_key_label = "tls";       // TLS key label on HSM, when used (for OpenSSL)
 static const string hsm_client_cert_label = "client"; // Uptane key label on HSM, when used (for OpenSSL)
+static const string os_release_filename = "/etc/os-release";
 
 static char WHEELS[] = {'|', '/', '-', '\\'};
 typedef std::map<std::string, string> http_headers;
@@ -58,9 +60,7 @@ struct Options {
 	string sota_config_dir;
 	bool start_daemon;
 	bool use_ostree_server;
-#ifdef AKLITE_TAGS
 	string pacman_tags;
-#endif
 #if defined DOCKER_COMPOSE_APP
 	string apps;
 	string restorable_apps;
@@ -68,15 +68,41 @@ struct Options {
 	bool is_prod;
 };
 
-static void _set_factory_option(std::string& factory) {
+static void _set_default_options(string & factory, string & pacman_tags) {
+
 	const char* device_factory_env_var = std::getenv("DEVICE_FACTORY");
+	ptree os_tree;
 	if (device_factory_env_var != nullptr) {
 		cout << "Using the device factory specified via the environment variable: "
 				 << device_factory_env_var << endl;
 		factory = device_factory_env_var;
 	}
-	if (factory.empty()) {
-		throw std::invalid_argument("Empty value of the device factory parameter");
+	if (boost::filesystem::exists(os_release_filename)) {
+		try{
+		read_ini(os_release_filename, os_tree);
+		}
+		catch (boost::property_tree::ini_parser_error const&){
+			cout << "Unable to parse ini file " << os_release_filename << endl;
+			return;
+		}
+		if (factory.empty()) {
+			try {
+				// value comes with ""
+				factory = os_tree.get<std::string>("LMP_FACTORY");
+				boost::algorithm::erase_all(factory, "\"");
+			}
+			catch (boost::property_tree::ptree_bad_path const&) {
+				cout << "Unable to read factory setting from "<< os_release_filename << endl;
+			}
+		}
+		try {
+			// value comes with ""
+			pacman_tags = os_tree.get<std::string>("LMP_FACTORY_TAG");
+			boost::algorithm::erase_all(pacman_tags, "\"");
+		}
+		catch (boost::property_tree::ptree_bad_path const&) {
+			cout << "Unable to read tags setting from "<< os_release_filename << endl;
+		}
 	}
 }
 
@@ -95,6 +121,9 @@ static void _set_prod_option(bool& is_prod) {
 
 static bool _get_options(int argc, char **argv, Options &options)
 {
+	string factory;
+	string pacman_tags;
+	_set_default_options(factory, pacman_tags);
 	po::options_description desc("lmp-device-register options");
 	desc.add_options()
 		("help", "print usage")
@@ -102,15 +131,8 @@ static bool _get_options(int argc, char **argv, Options &options)
 		("sota-dir,d", po::value<string>(&options.sota_config_dir)->default_value("/var/sota"),
 		 "The directory to install to keys and configuration to.")
 
-#ifdef AKLITE_TAGS
-#ifdef DEFAULT_TAG
-		("tags,t", po::value<string>(&options.pacman_tags)->default_value(DEFAULT_TAG),
-		 "Configure " SOTA_CLIENT " to only apply updates from Targets with these tags. Default is " DEFAULT_TAG)
-#else
-		("tags,t", po::value<string>(&options.pacman_tags),
+		("tags,t", po::value<string>(&options.pacman_tags)->default_value(pacman_tags),
 		 "Configure " SOTA_CLIENT " to only apply updates from Targets with these tags.")
-#endif
-#endif
 #if defined DOCKER_COMPOSE_APP
 		("apps,a", po::value<string>(&options.apps),
 		"Configure package-manager for this comma separate list of apps.")
@@ -158,13 +180,13 @@ static bool _get_options(int argc, char **argv, Options &options)
 		 "using one.")
 
 		("hsm-pin,P", po::value<string>(&options.hsm_pin),
-		 "The PKCS#11 PIN to set up on the HSM, if using one.");
+		 "The PKCS#11 PIN to set up on the HSM, if using one.")
+
+		("factory,f", po::value<string>(&options.factory)->default_value(factory),
+		 "The factory name to subscribe to");
 
 	po::options_description all_options("lmp-device-register all options");
 	all_options.add(desc);
-	all_options.add_options()
-		("stream,s", po::value<string>(&options.factory)->default_value(DEVICE_FACTORY),
-		 "The update factory to subscribe to: " DEVICE_FACTORY);
 
 	po::variables_map vm;
 	try {
@@ -175,8 +197,14 @@ static bool _get_options(int argc, char **argv, Options &options)
 			return false;
 		}
 		po::notify(vm);
-		_set_factory_option(options.factory);
 		_set_prod_option(options.is_prod);
+
+		if (factory.empty()) {
+			throw po::error("Missing value of the device factory parameter");
+		}
+		if (options.pacman_tags.empty()) {
+			throw po::error("Missing value of the tags parameter");
+		}
 	} catch (const po::error &o) {
 		cout << "ERROR: " << o.what() << endl;
 		cout << endl << desc << endl;
@@ -651,11 +679,8 @@ int main(int argc, char **argv)
 		device.put("overrides.import.tls_pkey_path", "");
 		device.put("overrides.import.tls_clientcert_path", "");
 	}
-#ifdef AKLITE_TAGS
-	if (!options.pacman_tags.empty()) {
-		device.put("overrides.pacman.tags", "\"" + options.pacman_tags + "\"");
-	}
-#endif
+	// options.pacman_tags can't be empty at this point
+	device.put("overrides.pacman.tags", "\"" + options.pacman_tags + "\"");
 #ifdef DOCKER_COMPOSE_APP
 	string apps_root = options.sota_config_dir + "/compose-apps";
 	device.put("overrides.pacman.type", "\"ostree+compose_apps\"");


### PR DESCRIPTION
Default tag can be read from the filesystem at runtime. When it's not possible to retreive from the files, lmp-device-register will prompt user for input.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>