### PR TITLE
Make writing of config files more safe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
 
 # find all required libraries
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost COMPONENTS filesystem program_options system REQUIRED)
+find_package(Boost COMPONENTS filesystem iostreams program_options system REQUIRED)
 find_package(CURL REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLIB REQUIRED glib-2.0)


### PR DESCRIPTION
The way we write out config files isn't completely safe. There are a couple of problems:

1) sota.toml can get written before other files like pkey.pem If the device reboots, it might come up and *think* it's registered but not actually have everything it needs.

2) We don't write files safely to disk
This could result in something like a zero-byte sota.toml.

This change introduces a safe way to write files. The same technique is used in Fioconfig where you:

 * write to a temp file
 * fsync this to disk
 * rename the file to the actual file

This sequence is power fail safe.

Additionally, we only write sota.toml to disk after we've written everything else.