### PR TITLE
main: refactor lmp-device-register

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,19 +46,25 @@ message(STATUS "Setting SOTA_CLIENT to ${SOTA_CLIENT}")
 add_definitions('-g')
 add_definitions('-Wall')
 
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
-
 # find all required libraries
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS filesystem iostreams program_options system REQUIRED)
 find_package(CURL REQUIRED)
 find_package(PkgConfig REQUIRED)
+find_package(OpenSSL 3.0.0 REQUIRED)
 pkg_search_module(GLIB REQUIRED glib-2.0)
 
 # Use C++11, but without GNU or other extensions
 set(CMAKE_CXX_STANDARD 11)
 
-add_executable(lmp-device-register src/main.cpp)
-target_include_directories(lmp-device-register PRIVATE ${GLIB_INCLUDE_DIRS})
-target_link_libraries(lmp-device-register ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${GLIB_LDFLAGS})
+if(DISABLE_PKCS11)
+add_executable(lmp-device-register src/main.cpp src/options.cpp src/auth.cpp src/pkcs11_stub.cpp src/openssl.cpp)
+target_link_libraries(lmp-device-register ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${GLIB_LDFLAGS} ${OPENSSL_LIBRARIES})
+else(DISABLE_PKCS11)
+pkg_check_modules(LIBP11 REQUIRED libp11)
+add_executable(lmp-device-register src/main.cpp src/options.cpp src/auth.cpp src/pkcs11.cpp src/openssl.cpp)
+target_link_libraries(lmp-device-register ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${GLIB_LDFLAGS} ${OPENSSL_LIBRARIES} ${LIBP11_LIBRARIES})
+endif(DISABLE_PKCS11)
+
+target_include_directories(lmp-device-register PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc> ${GLIB_INCLUDE_DIRS})
 install(TARGETS lmp-device-register RUNTIME DESTINATION bin)

--- a/inc/curl.hpp
+++ b/inc/curl.hpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef CURL_H
+#define CURL_H
+
+#include <boost/algorithm/string.hpp>
+#include <boost/beast/core/detail/base64.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/interprocess/sync/file_lock.hpp>
+
+#include <curl/curl.h>
+
+using boost::property_tree::ptree;
+using std::stringstream;
+using std::string;
+using std::cerr;
+using std::cout;
+using std::endl;
+
+static size_t write_sstream(void *buf, size_t size, size_t nmemb, void *userp)
+{
+	auto *body = static_cast<stringstream *>(userp);
+
+	body->write(static_cast<const char *>(buf), size * nmemb);
+
+	return size * nmemb;
+}
+
+class Curl {
+private:
+	string _url;
+public:
+	Curl(const string &url)
+	{
+		_url = url;
+		curl_global_init(CURL_GLOBAL_DEFAULT);
+		curl = curl_easy_init();
+		if (curl != nullptr) {
+			curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+		}
+	}
+	~Curl()
+	{
+		if (curl != nullptr) {
+			curl_easy_cleanup(curl);
+		}
+		curl_global_cleanup();
+	}
+	void ParseResponse(stringstream &body, ptree &resp)
+	{
+		try {
+			read_json(body, resp);
+		} catch (const boost::property_tree::json_parser::json_parser_error &e) {
+			cerr << "Unable to parse response from: " << _url << " Error is:" << endl;
+			cerr << " " <<  e.message() << endl;
+			body.seekg(0);
+			cerr << "Raw response was: " << body.str() << endl;
+		}
+	}
+	std::tuple<bool, string> PingEndpoint()
+	{
+		curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+		CURLcode res = curl_easy_perform(curl);
+		if (res != CURLE_OK) {
+			return { false,
+				"Unable to reach the device registration endpoint " + _url + "; err: " + curl_easy_strerror(res) };
+		}
+		gint64 code = 0;
+		CURLcode get_info_res = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
+		if (get_info_res != CURLE_OK) {
+			return { false,
+				"Error while checking the device registration endpoint; err: unable to get curl info: " + string(curl_easy_strerror(get_info_res)) };
+		}
+		if (code >= 500) {
+			// 401 or 400 is returned under normal circumstances what indicates that the OTA backend is reachable and functional
+			return { false,
+				"The device registration endpoint is not healthy" + _url + "; status code: " + std::to_string(code) };
+		}
+		return { true, "" };
+	}
+	gint64 Post(const http_headers &headers, const string &data, ptree &resp)
+	{
+		stringstream body;
+		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &write_sstream);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str());
+
+		struct curl_slist *chunk = nullptr;
+		for (auto item : headers) {
+			string header = item.first + ": " + item.second;
+			chunk = curl_slist_append(chunk, header.c_str());
+		}
+
+		if (chunk != nullptr) {
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+		}
+
+		CURLcode res = curl_easy_perform(curl);
+		if (res != CURLE_OK) {
+			cerr << "Unable to post to " << _url << ": " << curl_easy_strerror(res) << endl;
+			exit(1);
+		}
+
+		if (chunk != nullptr) {
+			curl_slist_free_all(chunk);
+		}
+
+		gint64 code = 0;
+		res = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
+		if (res != CURLE_OK) {
+			cerr << "Unable to get curl info: " << curl_easy_strerror(res) << endl;
+			exit(1);
+		}
+		ParseResponse(body, resp);
+		return code;
+	}
+private:
+	CURL *curl = nullptr;
+};
+
+#endif

--- a/inc/device_register.h
+++ b/inc/device_register.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef DEVICE_REGISTER_H
+#define DEVICE_REGISTER_H
+
+#include <exception>
+#include <fcntl.h>
+#include <glib.h>
+#include <iostream>
+#include <regex>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <unistd.h>
+
+#include <openssl/pem.h>
+#include <openssl/evp.h>
+#include <openssl/encoder.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/err.h>
+#include <openssl/buffer.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/beast/core/detail/base64.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/interprocess/sync/file_lock.hpp>
+
+#define __weak __attribute__((weak))
+
+/* OS definitions in os-release */
+#define LMP_OS_STR "/etc/os-release"
+#define OS_FACTORY_TAG "LMP_FACTORY_TAG"
+#define OS_FACTORY "LMP_FACTORY"
+
+/* Environment Variables */
+#define ENV_DEVICE_FACTORY "DEVICE_FACTORY"
+#define ENV_PRODUCTION "PRODUCTION"
+#define ENV_OAUTH_BASE "OAUTH_BASE"
+#define ENV_DEVICE_API "DEVICE_API"
+
+/* HSM defitions */
+#define HSM_TOKEN_STR "aktualizr"
+#define HSM_TLS_STR "tls"
+#define HSM_TLS_ID_STR "01"
+#define HSM_CRT_STR "client"
+#define HSM_CRT_ID 3
+#define HSM_CRT_ID_STR "03"
+
+/* Files */
+#define AKLITE_LOCK "/var/lock/aklite.lock"
+#define SOTA_DIR "/var/sota"
+#define SOTA_PEM "/client.pem"
+#define SOTA_SQL "/sql.db"
+
+using boost::property_tree::ptree;
+using std::stringstream;
+using std::string;
+using std::cerr;
+using std::cout;
+using std::endl;
+
+struct lmp_options {
+	string api_token_header;
+	string device_group;
+	string api_token;
+	string factory;
+	string hwid;
+	string uuid;
+	string name;
+	string hsm_module;
+	string hsm_so_pin;
+	string hsm_pin;
+	string sota_dir;
+	string pacman_tags;
+	bool start_daemon;
+	bool use_server;
+	bool production;
+	bool mlock;
+#if defined DOCKER_COMPOSE_APP
+	string apps;
+	string restorable_apps;
+#endif
+};
+
+typedef std::map<std::string, string> http_headers;
+
+int auth_register_device(http_headers &headers, ptree &device, ptree &resp);
+void auth_get_http_headers(lmp_options &opt, http_headers &headers);
+int auth_ping_server(void);
+
+int options_parse(int argc, char **argv, lmp_options &options);
+
+int openssl_create_csr(const lmp_options &options, string &key, string &csr);
+int openssl_gen_csr(const lmp_options &options, EVP_PKEY *pub, EVP_PKEY *priv,
+		    string &csr);
+
+int pkcs11_create_csr(const lmp_options &options, string &key, string &csr);
+int pkcs11_store_cert(lmp_options &opt, X509 *cert);
+int pkcs11_get_uuid(lmp_options &options);
+#endif

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <device_register.h>
+#include <curl.hpp>
+
+namespace b64 = boost::beast::detail::base64;
+using boost::property_tree::ptree;
+
+static string get_oauth_token(const string &factory, const string &device_uuid)
+{
+	const char *env = getenv(ENV_OAUTH_BASE);
+	char WHEELS[] = { '|', '/', '-', '\\' };
+	std::map<string, string> headers;
+	string data;
+	string url;
+	ptree json;
+
+	url = env == nullptr ? "https://app.foundries.io/oauth" : env;
+
+	data = "client_id=" + device_uuid;
+	data += "&scope=" + factory + ":devices:create";
+
+	gint64 code = Curl(url + "/authorization/device/").Post(headers, data, json);
+	if (code != 200) {
+		cerr << "Unable to create device authorization request: HTTP_" << code << endl;
+		exit(EXIT_FAILURE);
+	}
+
+	cout << endl;
+	cout << "----------------------------------------------------------------------------" << endl;
+	cout << "Visit the link below in your browser to authorize this new device. This link" << endl;
+	cout << "will expire in " << (json.get<int>("expires_in") / 60) << " minutes." << endl;
+	cout << "  Device Name: " << device_uuid << endl;
+	cout << "  User code: " << json.get<string>("user_code") << endl;
+	cout << "  Browser URL: " << json.get<string>("verification_uri") << endl;
+	cout << endl;
+
+	data = "grant_type=urn:ietf:params:oauth:grant-type:device_code";
+	data += "&device_code=" + json.get<string>("device_code");
+	data += "&client_id=" + device_uuid;
+	data += "&scope=" + factory + ":devices:create";
+
+	string msg;
+	int i = 0;
+	int interval = json.get<int>("interval");
+
+	while (true) {
+		gint64 code = Curl(url + "/token/").Post(headers, data, json);
+
+		if (code == 200)
+			return json.get<string>("access_token");
+
+		if (code != 400) {
+			cout << "HTTP(" << code << ") error..." << endl;
+			sleep(2);
+			continue;
+		}
+
+		/* Process */
+		if (json.get<string>("error") == "authorization_pending") {
+			cout << "Waiting for authorization ";
+			cout << WHEELS[i++ % sizeof(WHEELS)] << "\r" << std::flush;
+			sleep(interval);
+		} else {
+			cerr << "Error authorizing device: ";
+			cerr << json.get<string>("error_description") << endl;
+			exit(EXIT_FAILURE);
+		}
+	}
+}
+
+/*
+ * Headers of a request to the device registration endpoint DEVICE_API
+ * Default https://api.foundries.io/ota/devices/
+ */
+void auth_get_http_headers(lmp_options &opt, http_headers &headers)
+{
+	if (!opt.api_token.empty()) {
+		headers[opt.api_token_header] = opt.api_token;
+		return;
+	}
+
+	/*
+	 * If a token is not specified as a command line parameter then try
+	 * to get an oauth token from the Foundries' auth endpoint
+	 * https://app.foundries.io/oauth/authorization/device/
+	 */
+	cout << "Foundries providing auth token " << endl;
+	string token = get_oauth_token(opt.factory, opt.uuid);
+	string token_base64;
+
+	token_base64.resize(b64::encoded_size(token.size()));
+	b64::encode(&token_base64[0], token.data(), token.size());
+
+	headers["Authorization"] = "Bearer " + token_base64;
+}
+
+int auth_register_device(http_headers &headers, ptree &device, ptree &resp)
+{
+	const char *api = std::getenv(ENV_DEVICE_API);
+	stringstream data;
+	gint64 code;
+
+	if (api == nullptr)
+		api = DEVICE_API;
+
+	write_json(data, device);
+	code = Curl(api).Post(headers, data.str(), resp);
+	if (code != 201) {
+		cerr << "Unable to create device: HTTP_" << code << endl;
+		if (resp.data().length())
+			cerr << resp.data() << endl;
+
+		for (auto it: resp)
+			cerr << it.first << ": " << it.second.data() << endl;
+
+		return -1;
+	}
+
+	return 0;
+}
+
+int auth_ping_server(void)
+{
+	/* Get the device API from the environment */
+	const char *api = std::getenv(ENV_DEVICE_API);
+	if (api == nullptr)
+		api = DEVICE_API;
+
+	cout << "Using DEVICE_API: " << api << endl;
+	const auto ping_res{Curl(api).PingEndpoint()};
+
+	if (!std::get<0>(ping_res)) {
+		cerr << std::get<1>(ping_res) << endl;
+		return -1;
+	}
+
+	return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,804 +1,321 @@
 /*
- * Copyright (c) 2018 Open Source Foundries Limited
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2023 Foundries.io
  *
  * SPDX-License-Identifier: MIT
  */
 
-#include <fcntl.h>
-
-#include <curl/curl.h>
-#include <glib.h>
-#include <sys/stat.h>
-#include <stdio.h>
-#include <unistd.h>
-
-#include <exception>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <regex>
-
-#include <boost/algorithm/string.hpp>
-#include <boost/beast/core/detail/base64.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/iostreams/device/file_descriptor.hpp>
-#include <boost/iostreams/stream.hpp>
-#include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ini_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/interprocess/sync/file_lock.hpp>
+#include <device_register.h>
 
 namespace po = boost::program_options;
-using boost::property_tree::ptree;
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::string;
-using std::stringstream;
+namespace io = boost::iostreams;
 
-// OpenSSL works with object labels, while aktualizr works with IDs.
-static const string hsm_token_label = "aktualizr";
-static const string hsm_tls_key_id = "01";           // TLS key ID on HSM, when used (for sota.toml)
-static const string hsm_client_cert_id = "03";       // Client certificate's ID on HSM, when used (for sota.toml)
-static const string hsm_tls_key_label = "tls";       // TLS key label on HSM, when used (for OpenSSL)
-static const string hsm_client_cert_label = "client"; // Uptane key label on HSM, when used (for OpenSSL)
-static const string os_release_filename = "/etc/os-release";
-
-static char WHEELS[] = {'|', '/', '-', '\\'};
-typedef std::map<std::string, string> http_headers;
-
-struct Options {
-	string api_token;
-	string api_token_header;
-	string device_group;
-	string factory;
-	string hwid;
-	string uuid;
-	string name;
-	string hsm_module;
-	string hsm_so_pin;
-	string hsm_pin;
-	string sota_config_dir;
-	bool start_daemon;
-	bool use_ostree_server;
-	string pacman_tags;
-#if defined DOCKER_COMPOSE_APP
-	string apps;
-	string restorable_apps;
-#endif
-	bool is_prod;
-};
-
-static void _set_default_options(string & factory, string & pacman_tags) {
-
-	const char* device_factory_env_var = std::getenv("DEVICE_FACTORY");
-	ptree os_tree;
-	if (device_factory_env_var != nullptr) {
-		cout << "Using the device factory specified via the environment variable: "
-				 << device_factory_env_var << endl;
-		factory = device_factory_env_var;
-	}
-	if (boost::filesystem::exists(os_release_filename)) {
-		try{
-		read_ini(os_release_filename, os_tree);
-		}
-		catch (boost::property_tree::ini_parser_error const&){
-			cout << "Unable to parse ini file " << os_release_filename << endl;
-			return;
-		}
-		if (factory.empty()) {
-			try {
-				// value comes with ""
-				factory = os_tree.get<std::string>("LMP_FACTORY");
-				boost::algorithm::erase_all(factory, "\"");
-			}
-			catch (boost::property_tree::ptree_bad_path const&) {
-				cout << "Unable to read factory setting from "<< os_release_filename << endl;
-			}
-		}
-		try {
-			// value comes with ""
-			pacman_tags = os_tree.get<std::string>("LMP_FACTORY_TAG");
-			boost::algorithm::erase_all(pacman_tags, "\"");
-		}
-		catch (boost::property_tree::ptree_bad_path const&) {
-			cout << "Unable to read tags setting from "<< os_release_filename << endl;
-		}
-	}
-}
-
-static void _set_prod_option(bool& is_prod) {
-#ifdef PRODUCTION
-	is_prod = true;
-#else
-	is_prod = false;
-	const char* production_env_var = std::getenv("PRODUCTION");
-	if (production_env_var != nullptr) {
-		cout << "Enabling production client certificates via the environment variable" << endl;
-		is_prod = true;
-	}
-#endif
-}
-
-static bool _get_options(int argc, char **argv, Options &options)
+static string spawn(const string &cmd)
 {
-	string factory;
-	string pacman_tags;
-	_set_default_options(factory, pacman_tags);
-	po::options_description desc("lmp-device-register options");
-	desc.add_options()
-		("help", "print usage")
-
-		("sota-dir,d", po::value<string>(&options.sota_config_dir)->default_value("/var/sota"),
-		 "The directory to install to keys and configuration to.")
-
-		("tags,t", po::value<string>(&options.pacman_tags)->default_value(pacman_tags),
-		 "Configure " SOTA_CLIENT " to only apply updates from Targets with these tags.")
-#if defined DOCKER_COMPOSE_APP
-		("apps,a", po::value<string>(&options.apps),
-		"Configure package-manager for this comma separate list of apps.")
-		// Restorable Apps are enabled by default, its list == compose_apps or all Target apps
-		// --restorable-apps "app-01[,app-02]" : enable Restorable Apps usage, and its list == UNION(compose_apps, app-01[,app-02])
-		// `--restorable-apps ""` : disable Restorable Apps usage
-		 ("restorable-apps,A", po::value<string>(&options.restorable_apps)->default_value(" "),
-		 "Configure package-manager for this comma separate list of Restorable Apps."
-		 "If it is not specified, but a system image is preloaded with Restorable Apps then "
-		 "the Restorable App list is set to an empty list which means turning restorable App usage ON and"
-		 " the resultant list will be equal to the `apps` list."
-		 " Restorable App list = UNION(compose-apps, restorable-apps)")
-#endif
-		("hwid,i", po::value<string>(&options.hwid)->default_value(HARDWARE_ID),
-		 "An identifier for the device's hardware type.")
-
-		("uuid,u", po::value<string>(&options.uuid),
-		 "A per-device UUID. If not provided, one will be generated. "
-		 "This is associated with the device, e.g. as the CommonName field "
-		 "in certificates related to it.")
-
-		("name,n", po::value<string>(&options.name),
-		 "The name of the device as it should appear in the dashboard. If not specified, it will use the device's UUID")
-
-		("device-group,g", po::value<string>(&options.device_group),
-		 "Assign the device into a device group.")
-
-		("api-token,T", po::value<string>(&options.api_token),
-		 "Use an API token for authentication. If not specified, oauth2 will be used.")
-
-		("api-token-header,H", po::value<string>(&options.api_token_header)->default_value("OSF-TOKEN"),
-		 "Specify a HTTP header to be used for authentication.")
-
-		("start-daemon", po::value<bool>(&options.start_daemon)->default_value(true),
-		 "Start the " SOTA_CLIENT " systemd service automatically after performing the registration.")
-
-		("use-ostree-server", po::value<bool>(&options.use_ostree_server)->default_value(true),
-		 "Use OSTree Proxy server instead of Device Gateway to pull ostree repo from.")
-
-		("hsm-module,m", po::value<string>(&options.hsm_module),
-		 "The path to the PKCS#11 .so for the HSM, if using one.")
-
-		("hsm-so-pin,S", po::value<string>(&options.hsm_so_pin),
-		 "The PKCS#11 Security Officer PIN to set up on the HSM, if "
-		 "using one.")
-
-		("hsm-pin,P", po::value<string>(&options.hsm_pin),
-		 "The PKCS#11 PIN to set up on the HSM, if using one.")
-
-		("factory,f", po::value<string>(&options.factory)->default_value(factory),
-		 "The factory name to subscribe to.");
-
-	po::options_description all_options("lmp-device-register all options");
-	all_options.add(desc);
-
-	po::variables_map vm;
-	try {
-		po::store(po::parse_command_line(argc, reinterpret_cast<const char *const *>(argv), all_options), vm);
-		if (vm.count("help") != 0u) {
-			cout << desc;
-			cout << "Git Commit " << GIT_COMMIT << endl;
-			return false;
-		}
-		po::notify(vm);
-		_set_prod_option(options.is_prod);
-
-		if (factory.empty()) {
-			throw po::error("Missing value of the device factory parameter");
-		}
-		if (options.pacman_tags.empty()) {
-			throw po::error("Missing value of the tags parameter");
-		}
-	} catch (const po::error &o) {
-		cout << "ERROR: " << o.what() << endl;
-		cout << endl << desc << endl;
-		return false;
-	}
-	return true;
-}
-
-static size_t _write_sstream(void *buffer, size_t size, size_t nmemb, void *userp)
-{
-	auto *body = static_cast<stringstream *>(userp);
-	body->write(static_cast<const char *>(buffer), size * nmemb);
-	return size * nmemb;
-}
-
-class Curl {
-	private:
-	string _url;
-	public:
-	Curl(const string &url) {
-		_url = url;
-		curl_global_init(CURL_GLOBAL_DEFAULT);
-		curl = curl_easy_init();
-		if (curl != nullptr) {
-			curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-		}
-	}
-	~Curl() {
-		if(curl != nullptr) {
-			curl_easy_cleanup(curl);
-		}
-		curl_global_cleanup();
-	}
-	void ParseResponse(stringstream &body, ptree &resp) {
-		try {
-			read_json(body, resp);
-		} catch(const boost::property_tree::json_parser::json_parser_error &e) {
-			cerr << "Unable to parse response from: " << _url << " Error is:"<< endl;
-			cerr << " " <<  e.message() << endl;
-			body.seekg(0);
-			cerr << "Raw response was: " << body.str() << endl;
-		}
-	}
-	std::tuple<bool, string> PingEndpoint() {
-	  curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
-	  CURLcode res = curl_easy_perform(curl);
-	  if (res != CURLE_OK) {
-	    return {false, "Unable to reach the device registration endpoint " + _url + "; err: " + curl_easy_strerror(res)};
-	  }
-	  gint64 code = 0;
-	  CURLcode get_info_res = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
-	  if (get_info_res != CURLE_OK) {
-	    return {false, "Error while checking the device registration endpoint; err: unable to get curl info: " + string(curl_easy_strerror(get_info_res))};
-	  }
-	  if (code >= 500) {
-	    // 401 or 400 is returned under normal circumstances what indicates that the OTA backend is reachable and functional
-	    return {false, "The device registration endpoint is not healthy" + _url + "; status code: " + std::to_string(code)};
-	  }
-	  return {true, ""};
-	}
-	gint64 Post(const http_headers &headers, const string &data, ptree &resp)
-	{
-		stringstream body;
-		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &_write_sstream);
-		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str());
-
-		struct curl_slist *chunk = nullptr;
-		for (auto item : headers) {
-			string header = item.first + ": " + item.second;
-			chunk = curl_slist_append(chunk, header.c_str());
-		}
-
-		if (chunk != nullptr) {
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
-		}
-
-		CURLcode res = curl_easy_perform(curl);
-		if (res != CURLE_OK) {
-			cerr << "Unable to post to " << _url << ": " << curl_easy_strerror(res) << endl;
-			exit(1);
-		}
-
-		if (chunk != nullptr) {
-			curl_slist_free_all(chunk);
-		}
-		gint64 code = 0;
-		res = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
-		if (res != CURLE_OK) {
-			cerr << "Unable to get curl info: " << curl_easy_strerror(res) << endl;
-			exit(1);
-		}
-		ParseResponse(body, resp);
-		return code;
-	}
-	private:
-	CURL *curl = nullptr;
-};
-
-class TempDir {
-	public:
-	TempDir() {
-		path = (boost::filesystem::temp_directory_path() / boost::filesystem::unique_path()).native();
-		if (mkdir(path.c_str(), S_IRWXU) == -1) {
-			cerr << "Could not create temporary directory at " << path << endl;
-			exit(EXIT_FAILURE);
-		}
-	}
-	~TempDir() {
-		boost::filesystem::remove_all(path);
-	}
-	const string &GetPath() {return path;}
-
-	private:
-	string path;
-};
-
-
-static string _spawn(const string& cmd_line)
-{
-	g_autofree GError *error = nullptr;
-	g_autofree gchar *stdout_buff = nullptr;
-	g_autofree gchar *stderr_buff = nullptr;
+	g_autofree gchar *out{nullptr};
+	g_autofree gchar *err{nullptr};
+	g_autofree GError *e{nullptr};
 	gint status;
 
-	if (g_spawn_command_line_sync(cmd_line.c_str(), &stdout_buff, &stderr_buff, &status, &error) == 0) {
-		cerr << "Unable to run: " << cmd_line << endl;
-		cerr << "Error is: " << error->message << endl;
+	if (!g_spawn_command_line_sync(cmd.c_str(), &out, &err, &status, &e)) {
+		cerr << "Unable to run: " << cmd << endl;
+		cerr << "Error is: " << e->message << endl;
+
 		exit(EXIT_FAILURE);
 	}
+
 	if (status != 0) {
-		cerr << "Unable to run: " << cmd_line << endl;
-		cerr << "STDERR is: " << stderr_buff << endl;
-		exit(EXIT_FAILURE);
-	}
-	if (error != nullptr) {
-		cerr << "Unable to run: " << cmd_line << endl;
-		exit(EXIT_FAILURE);
-	}
-	return stdout_buff;
-}
+		cerr << "Unable to run: " << cmd << endl;
+		cerr << "STDERR is: " << err << endl;
 
-static string _pkcs11_tool(const string &module, const string &cmd)
-{
-	return _spawn("pkcs11-tool --module " + module + " " + cmd);
-}
-
-static string _pkcs11_tool(const string &module, const string &cmd, const string &pin)
-{
-	return _pkcs11_tool(module, "--pin " + pin + " " + cmd);
-}
-
-static void _setenv(const char *name, const char *value)
-{
-	int rc = setenv(name, value, 1);
-
-	if (rc != 0) {
-		cerr << "failed to set " << name << ": " << strerror(errno) << endl;
-		exit(EXIT_FAILURE);
-	}
-}
-
-static void _unsetenv(const char *name)
-{
-	int rc = unsetenv(name);
-
-	if (rc != 0) {
-		cerr << "failed to set " << name << ": " << strerror(errno) << endl;
-		exit(EXIT_FAILURE);
-	}
-}
-
-// There are two flows:
-//
-// 1. If hsm_module_in is empty or null, file-based keys will be
-//    generated and used. Return value is (key_id, csr).
-//
-// 2. Otherwise, we initialize a token on the PKCS#11 HSM with label
-//    aktualizr, generate the keypair there (label tls, ID 01), and
-//    extract the public half. Return value is (key_file, csr).
-static std::tuple<string, string> _create_cert(const Options &options, const string& uuid)
-{
-	TempDir tmp_dir;
-	string pkey;		// Private key data when no HSM used.
-	string pkey_file;	// Temporary file for private key when no HSM is used.
-
-	// Create the key.
-	if (options.hsm_module.empty()) {
-		// Create a file-based key.
-		pkey = _spawn("openssl ecparam -genkey -name prime256v1");
-		pkey_file = tmp_dir.GetPath() + "/pkey.pem";
-		std::ofstream pkey_out(pkey_file);
-		pkey_out << pkey << endl;
-		pkey_out.close();
-	} else {
-		// Initialize the HSM and create a key in it.
-		_pkcs11_tool(options.hsm_module,
-			     "--init-token --label " + hsm_token_label +
-			     " --so-pin " + options.hsm_so_pin);
-		_pkcs11_tool(options.hsm_module,
-			     "--init-pin --token-label " + hsm_token_label +
-			     " --so-pin " + options.hsm_so_pin +
-			     " --pin " + options.hsm_pin);
-		_pkcs11_tool(options.hsm_module,
-			     "--keypairgen --key-type EC:prime256v1"
-			     " --token-label " + hsm_token_label +
-			     " --id " + hsm_tls_key_id +
-			     " --label " + hsm_tls_key_label,
-			     options.hsm_pin);
-	}
-
-	// Create a CSR.
-	string csr = tmp_dir.GetPath() + "/device.csr";
-	string cnf = tmp_dir.GetPath() + "/device.cnf";
-	std::ofstream cnf_out(cnf);
-	if (!options.hsm_module.empty()) {
-		cnf_out << "openssl_conf = oc" << endl;
-		cnf_out << endl;
-		cnf_out << "[oc]" << endl;
-		cnf_out << "engines = eng" << endl;
-		cnf_out << endl;
-		cnf_out << "[eng]" << endl;
-		cnf_out << "pkcs11 = p11" << endl;
-		cnf_out << endl;
-		cnf_out << "[p11]" << endl;
-		cnf_out << "engine_id = pkcs11" << endl;
-		cnf_out << "dynamic_path = /usr/lib/engines-3/pkcs11.so" << endl;
-		cnf_out << "MODULE_PATH = " << options.hsm_module << endl;
-		cnf_out << "PIN = " << options.hsm_pin << endl;
-		cnf_out << "init = 0" << endl;
-		cnf_out << endl;
-	}
-	cnf_out << "[req]" << endl;
-	cnf_out << "prompt = no" << endl;
-	cnf_out << "distinguished_name = dn" << endl;
-	cnf_out << "req_extensions = ext" << endl;
-	cnf_out << endl;
-	cnf_out << "[dn]" << endl;
-	cnf_out << "CN=" << uuid << endl;
-	cnf_out << "OU=" << options.factory << endl;
-	if (options.is_prod) {
-		cnf_out << "businessCategory=production" << endl;
-	}
-	cnf_out << endl;
-	cnf_out << "[ext]" << endl;
-	cnf_out << "keyUsage=critical, digitalSignature" << endl;
-	cnf_out << "extendedKeyUsage=critical, clientAuth" << endl;
-	cnf_out.close();
-
-	if (options.hsm_module.empty()) {
-		csr = _spawn("openssl req -new -config " + cnf + " -key " + pkey_file);
-		return std::make_tuple(pkey, csr);
-	} else {
-		string key = "\"pkcs11:token=" + hsm_token_label +
-			";object=" + hsm_tls_key_label +
-			";type=private" +
-			";pin-value=" + options.hsm_pin + "\"";
-		// For some stupid reason, using OPENSSL_CONF in the
-		// environment works fine here, while using openssl
-		// req -new -config doesn't work with engines.
-		_setenv("OPENSSL_CONF", cnf.c_str());
-		csr = _spawn("openssl req -new -engine pkcs11 -keyform engine -key " + key);
-		_unsetenv("OPENSSL_CONF");
-		return std::make_tuple(hsm_tls_key_id, csr);
-	}
-}
-
-static string _get_oauth_token(const string &factory, const string &device_uuid)
-{
-	ptree json;
-	string data;
-	std::map<string, string> headers;
-	string url;
-	if (getenv("OAUTH_BASE") != nullptr) {
-		url = getenv("OAUTH_BASE");
-	} else {
-		url = "https://app.foundries.io/oauth";
-	}
-
-	data = "client_id=" + device_uuid;
-	data += "&scope=" + factory + ":devices:create";
-
-	gint64 code = Curl(url + "/authorization/device/").Post(headers, data, json);
-	if (code != 200) {
-		cerr << "Unable to create device authorization request: HTTP_" << code << endl;
 		exit(EXIT_FAILURE);
 	}
 
-	cout << endl;
-	cout << "----------------------------------------------------------------------------" << endl;
-	cout << "Visit the link below in your browser to authorize this new device. This link" << endl;
-	cout << "will expire in " << (json.get<int>("expires_in") / 60) << " minutes." << endl;
-	cout << "  Device Name: " << device_uuid << endl;
-	cout << "  User code: " << json.get<string>("user_code") << endl;
-	cout << "  Browser URL: " << json.get<string>("verification_uri") << endl;
-	cout << endl;
+	if (e != nullptr) {
+		cerr << "Unable to run: " << cmd << endl;
 
-	data = "grant_type=urn:ietf:params:oauth:grant-type:device_code";
-	data += "&device_code=" + json.get<string>("device_code");
-	data += "&client_id=" + device_uuid;
-	data += "&scope=" + factory + ":devices:create";
-
-	string msg;
-	int i=0, interval = json.get<int>("interval");
-
-	while (true) {
-		gint64 code = Curl(url + "/token/").Post(headers, data, json);
-		if(code == 200) {
-			return json.get<string>("access_token");
-		} else if (code == 400) {
-			if (json.get<string>("error") == "authorization_pending") {
-				cout << "Waiting for authorization ";
-				cout << WHEELS[i++ % sizeof(WHEELS)] << "\r" << std::flush;
-				sleep(interval);
-			} else {
-				cerr << "Error authorizing device: ";
-				cerr << json.get<string>("error_description") << endl;
-				exit(EXIT_FAILURE);
-			}
-		}
-		else {
-			cout << "HTTP(" << code << ") error. Pausing for 2 seconds" << endl;
-			sleep(2);
-		}
-	}
-}
-
-static void _assert_permissions(const string &sota_config_dir)
-{
-	string test_file = sota_config_dir + "/.test";
-	int fd = open(test_file.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-	if (fd < 0) {
-		cerr << "Unable to write to " << sota_config_dir << ". Please run as root" << endl;
 		exit(EXIT_FAILURE);
 	}
-	close(fd);
-	unlink(test_file.c_str());
-}
 
-static void _assert_not_registered(const string &sota_config_dir)
-{
-	const string db_path{sota_config_dir + "/sql.db"};
-	const string cert_path{sota_config_dir + "/client.pem"};
-	if (access(db_path.c_str(), F_OK) == 0 && access(cert_path.c_str(), F_OK) == 0) {
-		cerr << "ERROR: Device appears to already be registered in " <<  sota_config_dir << endl;
-		exit(EXIT_FAILURE);
-	}
-}
-
-static void _assert_not_running() {
-	const char* const lock_path{"/var/lock/aklite.lock"};
-	if (!boost::filesystem::exists(lock_path)) {
-		return;
-	}
-	boost::interprocess::file_lock lock{lock_path};
-	try {
-		if (!lock.try_lock_sharable()) {
-			cerr << "ERROR: " SOTA_CLIENT " daemon appears to be running" << endl;
-			exit(EXIT_FAILURE);
-		}
-	} catch (...) {
-		cerr << "ERROR: failed to check whether " SOTA_CLIENT " is running" << endl;
-		exit(EXIT_FAILURE);
-	}
+	return out;
 }
 
 static bool ends_with(const std::string &s, const std::string &suffix)
 {
-	string::size_type ssz = s.size(), sufsz = suffix.size();
-	return ssz >= sufsz && s.compare(ssz - sufsz, sufsz, suffix) == 0;
+	string::size_type sufsz = suffix.size();
+	string::size_type ssz = s.size();
+
+	return ssz >= sufsz && !s.compare(ssz - sufsz, sufsz, suffix);
 }
 
-static string get_device_id(const Options& options) {
-  string uuid; // resultant device ID, must be in UUID format
-  // Ensure a UUID is available.
-  if (!options.uuid.empty()) {
-    uuid = options.uuid;
-  } else if (!options.hsm_module.empty()) {
-    // Fetch from PKCS11 if available as part of the slot information
-    string slot_info = _pkcs11_tool(options.hsm_module, "--list-slots");
-    std::regex re("(Slot .*: )([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})");
-    std::smatch match;
-    std::regex_search(slot_info, match, re);
-    if (match.size() > 2) {
-      uuid = match.str(2);
-    }
-  }
-  // If ID is not specified as a command line param and cannot be fecthed from PKCS11 (slot uuid)
-  // then just use boost uuid generator (why not use it by default ???)
-  if (uuid.empty()) {
-    boost::uuids::uuid tmp = boost::uuids::random_generator()();
-    uuid = boost::uuids::to_string(tmp);
-  }
-  return uuid;
+static int check_device_status(lmp_options &opt)
+{
+	string crt = opt.sota_dir + SOTA_PEM;
+	string sql = opt.sota_dir + SOTA_SQL;
+	string tmp = opt.sota_dir + "/.tmp";
+	const char *const aklock{AKLITE_LOCK};
+
+	/* Check directory is writable */
+	int fd = open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
+		      S_IRUSR | S_IWUSR);
+	if (fd < 0) {
+		cerr << "Unable to write to " << opt.sota_dir << endl;
+		return -1;
+	}
+
+	close(fd);
+	unlink(tmp.c_str());
+
+	/* Check device was not been registered */
+	if (!access(sql.c_str(), F_OK) && !access(crt.c_str(), F_OK)) {
+		cerr << "ERROR: Device already registered in "
+		     << opt.sota_dir << endl;
+		return -1;
+	}
+
+	/* Check aklite not running */
+	if (!boost::filesystem::exists(aklock))
+		return 0;
+
+	boost::interprocess::file_lock lock{aklock};
+	try {
+		if (lock.try_lock_sharable())
+			return 0;
+
+		cerr << "ERROR: " SOTA_CLIENT " already running" << endl;
+		return -1;
+	} catch (...) {
+		cerr << "ERROR: is " SOTA_CLIENT " running ?" << endl;
+		return -1;
+	}
+
+	return 0;
 }
 
-// Write a file safely and atomically to disk
-static void write_safely(const string &name, const string &content) {
+static void put_compose_app_info(const lmp_options &opt, ptree &dev)
+{
+#ifdef DOCKER_COMPOSE_APP
+	string reset_apps = opt.sota_dir + "/reset-apps";
+	string apps = opt.sota_dir + "/compose-apps";
+
+	dev.put("overrides.pacman.type", "\"ostree+compose_apps\"");
+	dev.put("overrides.pacman.compose_apps_root", "\"" + apps + "\"");
+	if (!opt.apps.empty()) {
+		string str("overrides.pacman.compose_apps");
+		dev.put(str, "\"" + opt.apps + "\"");
+	}
+
+
+	dev.put("overrides.pacman.reset_apps_root", "\"" + reset_apps + "\"");
+	if (!opt.restorable_apps.empty()) {
+		string str("overrides.pacman.reset_apps");
+		dev.put(str, "\"" + opt.restorable_apps + "\"");
+		return;
+	}
+
+	/*
+	 * If restorable-apps was not specified but a system image is
+	 * preloaded with them, force restorable-apps ON
+	 */
+	if (boost::filesystem::exists(reset_apps)) {
+		cout << "Device is preloaded with Restorable Apps,"
+			" turning their usage ON" << endl;
+
+		dev.put("overrides.pacman.reset_apps", "\"\"");
+	}
+#endif
+}
+
+static void put_hsm_info(const lmp_options &opt, ptree &dev)
+{
+	if (opt.hsm_module.empty())
+		return;
+
+	dev.put("overrides.tls.pkey_source", "\"pkcs11\"");
+	dev.put("overrides.tls.cert_source", "\"pkcs11\"");
+	dev.put("overrides.storage.tls_pkey_path", "");
+	dev.put("overrides.storage.tls_clientcert_path", "");
+	dev.put("overrides.import.tls_pkey_path", "");
+	dev.put("overrides.import.tls_clientcert_path", "");
+}
+
+static void get_device_info(const lmp_options &opt, string &csr, ptree &dev)
+{
+	/* Device */
+	dev.put<bool>("use-ostree-server", opt.use_server);
+	dev.put("sota-config-dir", opt.sota_dir);
+	dev.put("hardware-id", opt.hwid);
+	dev.put("name", opt.name);
+	dev.put("uuid", opt.uuid);
+	dev.put("csr", csr);
+
+	/* HSM information */
+	put_hsm_info(opt, dev);
+
+	/* Compose apps information */
+	put_compose_app_info(opt, dev);
+
+	if (!opt.device_group.empty())
+		dev.put("group", opt.device_group);
+
+#ifdef AKLITE_TAGS
+	if (!opt.pacman_tags.empty())
+		dev.put("overrides.pacman.tags", "\"" + opt.pacman_tags + "\"");
+#endif
+}
+
+static void write_safely(const string &name, const string &content)
+{
 	auto tmp = name + ".tmp";
 
 	try {
-		boost::iostreams::stream<boost::iostreams::file_descriptor_sink> file(tmp);
+		io::stream<boost::iostreams::file_descriptor_sink> file(tmp);
 		file << content;
-
 		file.flush();
 		int rc = fsync(file->handle());
 		if (rc != 0) {
-			cerr << "Unable to write to " << tmp << ": " << strerror(errno) << endl;
-			exit(1);
+			cerr << "Unable to write to " << tmp <<
+				": " << strerror(errno) << endl;
+			exit(EXIT_FAILURE);
 		}
-	} catch (const std::exception& e) {
-		cerr << "Unable to open " << tmp << " for writing: " << e.what() << endl;
-		exit(1);
+	} catch (const std::exception &e) {
+		cerr << "Unable to open " << tmp <<
+			" for writing: " << e.what() << endl;
+		exit(EXIT_FAILURE);
 	}
 	int rc = rename(tmp.c_str(), name.c_str());
 	if (rc != 0) {
-		cerr << "Unable to create " << name << ": " << strerror(errno) << endl;
-		exit(1);
+		cerr << "Unable to create " << name <<
+			": " << strerror(errno) << endl;
+		exit(EXIT_FAILURE);
 	}
+}
+
+/*
+ * We additionally write the entire p11 section. We can't tell the server the
+ * PIN, and don't want to parse/modify TOML to add it, so just write the whole
+ * thing to /var/sota/
+ */
+static void fill_p11_engine_info(lmp_options &opt, stringstream &sota_toml)
+{
+	sota_toml << "[p11]" << endl;
+	sota_toml << "module = \"" << opt.hsm_module << "\"" << endl;
+	sota_toml << "pass = \"" << opt.hsm_pin << "\"" << endl;
+	sota_toml << "tls_pkey_id = \"" <<  HSM_TLS_ID_STR << "\"" << endl;
+	sota_toml << "tls_clientcert_id = \"" << HSM_CRT_ID_STR << "\"" << endl;
+	sota_toml << endl;
+}
+
+static int populate_sota_dir(lmp_options &opt, ptree &resp, string &pkey)
+{
+	cout << "Populate sota directory." << endl;
+
+	if (opt.hsm_module.empty()) {
+		/* Write the private key */
+		std::ofstream out(opt.sota_dir + "/pkey.pem");
+		out << pkey;
+		out.close();
+	}
+
+	stringstream sota_toml;
+	for (auto it: resp) {
+		string name = opt.sota_dir + "/" + it.first;
+
+		if (ends_with(name, "sota.toml")) {
+			sota_toml << it.second.data() << endl;
+
+			if (!opt.hsm_module.empty())
+				fill_p11_engine_info(opt, sota_toml);
+		} else {
+			write_safely(name, it.second.data());
+
+			if (!ends_with(name, ".pem"))
+				continue;
+
+			/* Import the certificate also to PKCS#11 database */
+			if (!opt.hsm_module.empty()) {
+				/* Read back the file into X509 */
+				FILE *file = NULL;
+				X509 *crt = NULL;
+
+				file = fopen(name.c_str(), "rb");
+				if (!file)
+					return -1;
+
+				crt = PEM_read_X509(file, NULL, 0, NULL);
+				if (!crt)
+					return -1;
+
+				fclose(file);
+
+				if (pkcs11_store_cert(opt, crt))
+					return -1;
+			}
+		}
+	}
+
+	write_safely(opt.sota_dir + "/sota.toml", sota_toml.str());
+
+	return 0;
+}
+
+/*
+ * Create a Certificate Signing Request
+ */
+int create_csr(const lmp_options &opt, string &key, string &csr)
+{
+	if (opt.hsm_module.empty())
+		return openssl_create_csr(opt, key, csr);
+
+	return pkcs11_create_csr(opt, key, csr);
 }
 
 int main(int argc, char **argv)
 {
-	Options options;
-	if (!_get_options(argc, argv, options)) {
-		return EXIT_FAILURE;
-	}
-
-	if (!options.hsm_module.empty()) {
-		if (options.hsm_so_pin.empty() || options.hsm_pin.empty()) {
-			cerr << "--hsm-module given without both --hsm-so-pin and --hsm-pin" << endl;
-			return EXIT_FAILURE;
-		}
-	} else if (!options.hsm_so_pin.empty() || !options.hsm_pin.empty()) {
-		cerr << "--hsm-module missing but --hsm-so-pin and/or --hsm-pin given" << endl;
-		return EXIT_FAILURE;
-	}
-
-	_assert_permissions(options.sota_config_dir);
-	_assert_not_registered(options.sota_config_dir);
-	_assert_not_running();
-
-	const string final_uuid{get_device_id(options)};
-
-	http_headers headers{
-	    {"Content-type", "application/json"}
-	}; // headers of a request to the device registration endpoint DEVICE_API (by default https://api.foundries.io/ota/devices/)
-	if (options.api_token.empty()) {
-	  // if a token is not specified as a command line parameter then try to get an oauth token
-	  // from the Foundries' auth endpoint (https://app.foundries.io/oauth/authorization/device/)
-	  cout << "Token is not specified, getting an oauth token from Foundries' auth endpoint..." << endl;
-	  string token = _get_oauth_token(options.factory, final_uuid);
-	  string token_base64;
-	  token_base64.resize(boost::beast::detail::base64::encoded_size(token.size()));
-	  boost::beast::detail::base64::encode(&token_base64[0], token.data(), token.size());
-
-	  headers["Authorization"] = "Bearer " + token_base64;
-	} else {
-	  headers[options.api_token_header] = options.api_token;
-	}
-
-	const char* device_api = std::getenv("DEVICE_API");
-	if (device_api != nullptr) {
-	  cout << "Using DEVICE_API: " << device_api << endl;
-	} else {
-	  device_api = DEVICE_API;
-	}
-
-	// check if the device registration server and endpoint are reachable before creating a device key&CSR and posting request to the backend.
-	const auto ping_res{Curl(device_api).PingEndpoint()};
-	if (!std::get<0>(ping_res)) {
-	  cerr << std::get<1>(ping_res) << endl;
-	  exit(EXIT_FAILURE);
-	}
-
-	string pkey, csr;
-	std::tie(pkey, csr) = _create_cert(options, final_uuid);
-	if (options.name.empty()) {
-		options.name = final_uuid;
-	}
-	cout << "Registering device, " << options.name << ", to factory " << options.factory << "." << endl;
-	if (options.uuid.empty()) {
-		cout << "Device UUID: " << final_uuid << endl;
-	}
-
-	ptree device;
-	device.put("name", options.name);
-	device.put("uuid", final_uuid);
-	device.put("csr", csr);
-	device.put("hardware-id", options.hwid);
-	device.put("sota-config-dir", options.sota_config_dir);
-	device.put<bool>("use-ostree-server", options.use_ostree_server);
-	if (!options.hsm_module.empty()) {
-		device.put("overrides.tls.pkey_source", "\"pkcs11\"");
-		device.put("overrides.tls.cert_source", "\"pkcs11\"");
-		device.put("overrides.storage.tls_pkey_path", "");
-		device.put("overrides.storage.tls_clientcert_path", "");
-		device.put("overrides.import.tls_pkey_path", "");
-		device.put("overrides.import.tls_clientcert_path", "");
-	}
-	// options.pacman_tags can't be empty at this point
-	device.put("overrides.pacman.tags", "\"" + options.pacman_tags + "\"");
-#ifdef DOCKER_COMPOSE_APP
-	string apps_root = options.sota_config_dir + "/compose-apps";
-	device.put("overrides.pacman.type", "\"ostree+compose_apps\"");
-	device.put("overrides.pacman.compose_apps_root", "\"" + apps_root + "\"");
-	if (!options.apps.empty()) {
-		device.put("overrides.pacman.compose_apps", "\"" + options.apps + "\"");
-	}
-	string reset_apps_root = options.sota_config_dir + "/reset-apps";
-	device.put("overrides.pacman.reset_apps_root", "\"" + reset_apps_root + "\"");
-
-	if (!options.restorable_apps.empty()) {
-		device.put("overrides.pacman.reset_apps", "\"" + options.restorable_apps + "\"");
-	} else if (boost::filesystem::exists(reset_apps_root)) {
-		// if `restorable-apps` is not specified but a system image is preloaded with Restorable Apps then force restorable-apps ON
-		cout << "Device is preloaded with Restorable Apps, turning their usage ON" << endl;
-		device.put("overrides.pacman.reset_apps", "\"\"");
-	}
-#endif
-	if (!options.device_group.empty()) {
-		device.put("group", options.device_group);
-	}
-	stringstream data;
-	write_json(data, device);
-
+	http_headers headers{{ "Content-type", "application/json" }};
+	lmp_options opt;
+	ptree info;
 	ptree resp;
-	gint64 code = Curl(device_api).Post(headers, data.str(), resp);
-	if (code != 201) {
-		cerr << "Unable to create device: HTTP_" << code << endl;
-		if (resp.data().length() != 0) {
-			cerr << resp.data() << endl;
-		}
-		for (auto it: resp) {
-			const auto resp_elem{it.first};
-			if (resp_elem == "errors") {
-				cerr << resp_elem << ":" << endl;
-				for (auto it_err: it.second) {
-					cerr << '\t' << it_err.first << ": " << it_err.second.data() << endl;
-				}
-			} else {
-				cerr << it.first << ": " << it.second.data() << endl;
-			}
-		}
+	string key;
+	string csr;
+
+	if (options_parse(argc, argv, opt))
 		exit(EXIT_FAILURE);
-	}
-	if (options.hsm_module.empty()) {
-		// If the private key is meant to be a file, put it in the right place.
-		std::ofstream out(options.sota_config_dir + "/pkey.pem");
-		out << pkey;
-		out.close();
-	}
-	stringstream sota_toml;
-	for (auto it: resp) {
-		string name = options.sota_config_dir + "/" + it.first;
 
-		if (ends_with(name, "sota.toml")) {
-			sota_toml << it.second.data() << endl;
-			if (!options.hsm_module.empty()) {
-				// We additionally write the entire p11 section. (We can't tell the server
-				// the PIN, and don't want to parse/modify TOML to add it, so just write
-				// the whole thing.)
-				sota_toml << "[p11]" << endl;
-				sota_toml << "module = \"" << options.hsm_module << "\"" << endl;
-				sota_toml << "pass = \"" << options.hsm_pin << "\"" << endl;
-				sota_toml << "tls_pkey_id = \"" << hsm_tls_key_id << "\"" << endl;
-				sota_toml << "tls_clientcert_id = \"" << hsm_client_cert_id << "\"" << endl;
-				sota_toml << endl;
-			}
-		} else {
-			write_safely(name, it.second.data());
-		}
+	/* Check if this device can be registered */
+	if (check_device_status(opt))
+		exit(EXIT_FAILURE);
 
-		if (!options.hsm_module.empty() && ends_with(name, ".pem")) {
-			// The client cert is now saved on disk, but  needs to be stored in
-			// the HSM. The copy we leave in sota_config_dir is just a "courtesy".
-			TempDir tmp_dir;
-			string client_der = tmp_dir.GetPath() + "/client.der";
-			_spawn("openssl x509 -inform pem -in " + name + string(" -out ").append(client_der));
-			_pkcs11_tool(options.hsm_module, "-w " + client_der + string(" -y cert --id ").append(hsm_client_cert_id), options.hsm_pin);
-		}
-	}
-	write_safely(options.sota_config_dir + "/sota.toml", sota_toml.str());
+	/* Get the HTTP headers */
+	auth_get_http_headers(opt, headers);
+
+	/* Check that the registration server and endpoint are reachable */
+	if (auth_ping_server())
+		exit(EXIT_FAILURE);
+
+	/* Create the key pair and the certificate request */
+	if (create_csr(opt, key, csr))
+		exit(EXIT_FAILURE);
+
+	/* Get the device information */
+	get_device_info(opt, csr, info);
+
+	/* Register the device with the factory */
+	cout << "Registering device " << opt.name <<
+		" with factory " << opt.factory << endl;
+
+	if (auth_register_device(headers, info, resp))
+		exit(EXIT_FAILURE);
+
+	/* Store the login details */
+	if (populate_sota_dir(opt, resp, key))
+		exit(EXIT_FAILURE);
+
 	cout << "Device is now registered." << endl;
 
-	if (options.start_daemon) {
+	if (opt.start_daemon) {
 		cout << "Starting " SOTA_CLIENT " daemon" << endl;
-		_spawn("systemctl start " SOTA_CLIENT);
+		spawn("systemctl start " SOTA_CLIENT);
 	}
 
-	return EXIT_SUCCESS;
+	exit(EXIT_SUCCESS);
 }

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -1,0 +1,187 @@
+ /*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <device_register.h>
+
+#define leave \
+({ cerr << "Error !"<< endl; \
+   cerr << "  Commit : " << GIT_COMMIT << endl; \
+   cerr << "  File: openssl.cpp, Func: " << __func__ \
+   << " Line: " << __LINE__ << endl; \
+   return -1; })
+
+static int add_ext(STACK_OF(X509_EXTENSION)*sk, int nid, char *value)
+{
+	X509_EXTENSION *ex = X509V3_EXT_conf_nid(NULL, NULL, nid, value);
+
+	X509_EXTENSION_set_critical(ex, 1);
+	if (!ex)
+		return -1;
+
+	sk_X509_EXTENSION_push(sk, ex);
+	return 0;
+}
+
+/* Use external keys (not created with OpenSSL) to generate a CSR */
+int openssl_gen_csr(const lmp_options &opt, EVP_PKEY *pub, EVP_PKEY *priv,
+		    string &csr)
+{
+	STACK_OF(X509_EXTENSION) *ext = NULL;
+	X509_NAME *name = NULL;;
+	X509_REQ *req = NULL;
+	BUF_MEM *bptr = NULL;
+	BIO *bio = NULL;
+
+	bio = BIO_new(BIO_s_mem());
+	req = X509_REQ_new();
+	name = X509_REQ_get_subject_name(req);
+
+	if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+				       (const unsigned char *)
+				       opt.uuid.c_str(), -1, -1, 0) != 1)
+		leave;
+
+	if (X509_NAME_add_entry_by_txt(name, "OU", MBSTRING_ASC,
+				       (const unsigned char *)
+				       opt.factory.c_str(), -1, -1, 0) != 1)
+		leave;
+
+	if (opt.production) {
+		if (X509_NAME_add_entry_by_txt(name, LN_businessCategory,
+					       MBSTRING_ASC,
+					       (const unsigned char *)
+					       "production", -1, -1, 0) != 1)
+			leave;
+	}
+
+	ext = X509_REQ_get_extensions(req);
+	if (!ext)
+		leave;
+
+	if (add_ext(ext, NID_key_usage, (char *)"digitalSignature"))
+		leave;
+
+	if (add_ext(ext, NID_ext_key_usage, (char *)"clientAuth"))
+		leave;
+
+	if (X509_REQ_add_extensions(req, ext) != 1)
+		leave;
+
+	if (X509_REQ_set_pubkey(req, pub) != 1)
+		leave;
+
+	X509_REQ_sign(req, priv, EVP_sha256());
+
+	if (PEM_write_bio_X509_REQ(bio, req) != 1)
+		leave;
+
+	BIO_write(bio, "\0", 1);
+	BIO_get_mem_ptr(bio, &bptr);
+	X509_REQ_free(req);
+
+	/* Output */
+	csr = bptr->data;
+
+	bptr->data = NULL;
+	BIO_free_all(bio);
+
+	return 0;
+}
+
+int openssl_create_csr(const lmp_options &options, string &pkey, string &csr)
+{
+	STACK_OF(X509_EXTENSION) *ext = NULL;
+	X509_NAME *name = NULL;
+	X509_REQ *req = NULL;
+	BUF_MEM *bptr = NULL;
+	BIO *bio = NULL;
+	OSSL_ENCODER_CTX *ectx = NULL;
+	unsigned char *data = NULL;
+	EVP_PKEY_CTX *kctx = NULL;
+	EVP_PKEY *key = NULL;
+	size_t len = 0;
+
+	bio = BIO_new(BIO_s_mem());
+	req = X509_REQ_new();
+	name = X509_REQ_get_subject_name(req);
+
+	if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+				       (const unsigned char *)
+				       options.uuid.c_str(), -1, -1, 0) != 1)
+		leave;
+
+	if (X509_NAME_add_entry_by_txt(name, "OU", MBSTRING_ASC,
+				       (const unsigned char *)
+				       options.factory.c_str(), -1, -1, 0) != 1)
+		leave;
+
+
+	if (options.production) {
+		if (X509_NAME_add_entry_by_txt(name, LN_businessCategory,
+					       MBSTRING_ASC,
+					       (const unsigned char *)
+					       "production", -1, -1, 0) != 1)
+			leave;
+	}
+
+	ext = X509_REQ_get_extensions(req);
+
+	if (add_ext(ext, NID_key_usage, (char *)"digitalSignature"))
+		leave;
+
+	if (add_ext(ext, NID_ext_key_usage, (char *)"clientAuth"))
+		leave;
+
+	if (X509_REQ_add_extensions(req, ext) != 1)
+		leave;
+
+	kctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+	if (!kctx)
+		leave;
+
+	if (EVP_PKEY_keygen_init(kctx) <= 0)
+		leave;
+
+	if (EVP_PKEY_CTX_set_group_name(kctx, "prime256v1") <= 0)
+		leave;
+
+	if (EVP_PKEY_keygen(kctx, &key) <= 0)
+		leave;
+
+	ectx = OSSL_ENCODER_CTX_new_for_pkey(key, OSSL_KEYMGMT_SELECT_ALL,
+					     "PEM", NULL, NULL);
+	if (!ectx)
+		leave;
+
+	if (OSSL_ENCODER_to_data(ectx, &data, &len) != 1)
+		leave;
+
+	OSSL_ENCODER_CTX_free(ectx);
+
+	if (X509_REQ_set_pubkey(req, key) != 1)
+		leave;
+
+	if (!X509_REQ_sign(req, key, EVP_sha256()))
+		leave;
+
+	if (PEM_write_bio_X509_REQ(bio, req) != 1)
+		leave;
+
+	EVP_PKEY_free(key);
+	BIO_write(bio, "\0", 1);
+	BIO_get_mem_ptr(bio, &bptr);
+	X509_REQ_free(req);
+
+	/* Output */
+	csr = bptr->data;
+	pkey = string(reinterpret_cast<char *>(data));
+
+	memset(data, 0, len);
+	bptr->data = NULL;
+	BIO_free_all(bio);
+
+	return 0;
+}

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "device_register.h"
+
+using boost::property_tree::ptree;
+
+namespace po = boost::program_options;
+
+#define OPT_DEF_STR(str, option, def, help) \
+(str, po::value<string>(&option)->default_value(def), help)
+
+#define OPT_DEF_BOOL(str, option, def, help) \
+(str, po::value<bool>(&option)->default_value(def), help)
+
+#define OPT_STR(str, option, help) \
+(str, po::value<string>(&option), help)
+
+#define MLOCK_HELP \
+"Avoid paging out the process memory during execution."
+
+#define RESTORABLE_APP_HELP \
+"Configure package-manager for this comma separate list of Restorable Apps. "  \
+"If it is not specified, but a system image is preloaded with Restorable "     \
+"Apps then the Restorable App list is set to an empty list which means "       \
+"turning restorable App usage ON and the resultant list will be equal to the " \
+"apps list. Restorable App list = UNION(compose-apps, restorable-apps)"
+
+#define UUID_HELP \
+"A per-device UUID. If not provided, one will be generated. This is "          \
+"associated with the device, e.g. as the CommonName field in certificates "    \
+"related to it."
+
+#define OSTREE_SRV_HELP \
+"Use OSTree Proxy server instead of the Device Gateway to pull the ostree repo."
+
+#define NAME_HELP \
+"The name of the device as it should appear in the dashboard. When not "       \
+"specified, the device's UUID will be used instead."
+
+#define API_TOKEN_HELP \
+"API token for authentication. If not provided, oauth2 will be used instead."
+
+#define APPS_HELP \
+"Configure package-manager for this comma separate list of apps."
+
+#define TAGS_HELP \
+"Configure " SOTA_CLIENT " to only apply updates from Targets with these tags."
+
+#define DAEMON_HELP \
+"Start the " SOTA_CLIENT " systemd service after registration."
+
+#define SOTA_DIR_HELP \
+"The directory to install to keys and configuration to."
+
+#define API_TOKEN_HDR_HELP \
+"The HTTP header to use for authentication."
+
+#define HWID_HELP \
+"The hardware identifier for the device type."
+
+#define DEVICE_GROUP_HELP \
+"Assign this device to a device group."
+
+#define PRODUCTION_HELP \
+"Mark the device as a production device."
+
+#define FACTORY_HELP \
+"The factory name to subscribe to."
+
+#define HSM_SO_PIN_HELP \
+"The PKCS#11 security officer pin - HSM only."
+
+#define HSM_HELP \
+"The PKCS#11 implementation (.so library) - HSM only."
+
+#define HSM_PIN_HELP \
+"The PKCS#11 pin - HSM only."
+
+static void get_factory_tags_info(const string os_release, string &factory,
+				  string &tag)
+{
+	const char *env = std::getenv(ENV_DEVICE_FACTORY);
+	ptree os_info;
+
+	if (env != nullptr) {
+		cout << "Factory read from environment" << endl;
+		factory = env;
+	}
+
+	if (!boost::filesystem::exists(os_release))
+		return;
+
+	try {
+		read_ini(os_release, os_info);
+	} catch (boost::property_tree::ini_parser_error const &) {
+		cout << "Can't parse file " << os_release << endl;
+	}
+
+	try {
+		tag = os_info.get<std::string>(OS_FACTORY_TAG);
+		boost::algorithm::erase_all(tag, "\"");
+		cout << "Tag read from " << os_release << endl;
+	} catch (boost::property_tree::ptree_bad_path const &) {
+		cout << "Can't read tag from " << os_release << endl;
+	}
+
+	if (!factory.empty())
+		return;
+
+	try {
+		factory = os_info.get<std::string>(OS_FACTORY);
+		boost::algorithm::erase_all(factory, "\"");
+		cout << "Factory read from " << os_release << endl;
+	} catch (boost::property_tree::ptree_bad_path const &) {
+		cout << "Can't read factory from " << os_release << endl;
+	}
+}
+
+static void set_default_options(lmp_options &opt, string factory, string tags,
+				po::options_description &desc)
+{
+	bool prod = false;
+
+#if defined PRODUCTION
+	prod = true;
+#endif
+	desc.add_options()
+
+	("help", "print usage")
+	OPT_DEF_BOOL("use-ostree-server", opt.use_server, true, OSTREE_SRV_HELP)
+	OPT_DEF_BOOL("production,p", opt.production, prod, PRODUCTION_HELP)
+	OPT_DEF_BOOL("start-daemon", opt.start_daemon,true, DAEMON_HELP)
+	OPT_DEF_STR("sota-dir,d", opt.sota_dir, SOTA_DIR, SOTA_DIR_HELP)
+	OPT_STR("device-group,g", opt.device_group, DEVICE_GROUP_HELP)
+	OPT_DEF_STR("factory,f", opt.factory, factory, FACTORY_HELP)
+	OPT_STR("hsm-so-pin,S", opt.hsm_so_pin, HSM_SO_PIN_HELP)
+	OPT_DEF_BOOL("mlock-all,l", opt.mlock, true, MLOCK_HELP)
+	OPT_DEF_STR("hwid,i", opt.hwid, HARDWARE_ID, HWID_HELP)
+	OPT_DEF_STR("tags,t", opt.pacman_tags, tags, TAGS_HELP)
+	OPT_STR("api-token,T", opt.api_token, API_TOKEN_HELP)
+	OPT_STR("hsm-module,m", opt.hsm_module, HSM_HELP)
+	OPT_STR("hsm-pin,P", opt.hsm_pin, HSM_PIN_HELP)
+	OPT_STR("uuid,u", opt.uuid, UUID_HELP)
+	OPT_STR("name,n", opt.name, NAME_HELP)
+	OPT_DEF_STR("api-token-header,H",
+		    opt.api_token_header, "OSF-TOKEN",API_TOKEN_HDR_HELP)
+
+#if defined DOCKER_COMPOSE_APP
+	OPT_STR("apps,a", opt.apps, APPS_HELP)
+	/*
+	 * Enabled by default, list == compose_apps (or all Target apps)
+	 *
+	 * --restorable-apps "app-01[,app-02]"
+	 *       enable
+	 *       list == UNION(compose_apps, app-01[,app-02])
+	 *
+	 * --restorable-apps ""
+	 *       disable
+	 */
+	OPT_DEF_STR("restorable-apps,A", opt.restorable_apps," ",
+		    RESTORABLE_APP_HELP)
+#endif
+	;
+}
+
+static int parse_command_line(int argc, char **argv,
+			       po::options_description &desc)
+{
+	po::options_description all("lmp-device-register all options");
+	po::variables_map vm;
+
+	all.add(desc);
+	try {
+		po::store(
+			po::parse_command_line(
+				argc,
+				reinterpret_cast<const char *const *>(argv),
+				all),
+			vm);
+
+		if (vm.count("help")) {
+			cout << desc;
+			cout << "Git Commit " << GIT_COMMIT << endl;
+			return -1;
+		}
+		po::notify(vm);
+	} catch (const po::error &o) {
+		cout << "ERROR: " << o.what() << endl;
+		cout << endl << desc << endl;
+		return -1;
+	}
+
+	return 0;
+}
+
+static void get_uuid(lmp_options &opt)
+{
+	boost::uuids::uuid tmp;
+
+	/* Use PKCS#11 if the hsm_module was configured */
+	if (pkcs11_get_uuid(opt))
+		cerr << "WARN: can't get UUID from PKCS token" << endl;
+
+	if (opt.uuid.empty()) {
+		tmp = boost::uuids::random_generator()();
+		opt.uuid = boost::uuids::to_string(tmp);
+		cout << "UUID: " << opt.uuid <<" [Random]" << endl;
+	}
+}
+
+int options_parse(int argc, char **argv, lmp_options &opt)
+{
+	po::options_description desc("lmp-device-register options");
+	string factory;
+	string tags;
+
+	/* Read from environment or configuration file */
+	get_factory_tags_info(LMP_OS_STR, factory, tags);
+
+	set_default_options(opt, factory, tags, desc);
+
+	/* Command line takes precedence over any parameters */
+	if (parse_command_line(argc, argv, desc))
+		return -1;
+
+	if (opt.factory.empty()) {
+		cerr << "Missing factory definition" << endl;
+		return -1;
+	}
+
+	if (opt.pacman_tags.empty()) {
+		cerr << "Missing tag definition" << endl;
+		return -1;
+	}
+
+	if (!opt.hsm_module.empty())
+		if (opt.hsm_so_pin.empty() || opt.hsm_pin.empty()) {
+			cerr << "HSM incorrectly configured" << endl;
+			return -1;
+		}
+
+	if (opt.hsm_module.empty())
+		if (!opt.hsm_so_pin.empty() ||
+		    !opt.hsm_pin.empty()) {
+			cerr <<  "HSM incorrectly configured" << endl;
+			return -1;
+		}
+
+	/* Production env ENABLED takes precedence over config disabled */
+	opt.production = std::getenv(ENV_PRODUCTION) != nullptr ?
+			true : opt.production;
+
+	/* Set the UUID from OS-Release, HSM or RNG */
+	if (opt.uuid.empty())
+		get_uuid(opt);
+
+	/* Set the factory name from the UUID if not speficied */
+	if (opt.name.empty()) {
+		cout << "Setting factory name to UUID " << endl;
+		opt.name = opt.uuid;
+	}
+
+	if (opt.mlock) {
+		if (mlockall(MCL_CURRENT | MCL_FUTURE)) {
+			cout << "Error locking memory " << endl;
+			return -1;
+		}
+	}
+
+	cout << "PID memory " << (opt.mlock ? "locked" : "unlocked") <<  endl;
+
+	return 0;
+}

--- a/src/pkcs11.cpp
+++ b/src/pkcs11.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <device_register.h>
+#include <libp11.h>
+
+#define leave \
+({ cerr << "Error !"<< endl; \
+   cerr << " Commit: " << GIT_COMMIT << endl; \
+   cerr << " File: pkcs11.cpp, Func: " << __func__ \
+   << " Line: " << __LINE__ << endl; \
+   return -1; })
+
+/* HSM default information */
+static const struct lmp_hsm {
+	string token;
+	string tls_lbl;
+	string tls_id;
+	string crt_lbl;
+	unsigned char crt_id;
+} hsm_cfg = {
+	.token = HSM_TOKEN_STR,
+	.tls_lbl = HSM_TLS_STR,
+	.tls_id = HSM_TLS_ID_STR,
+	.crt_lbl = HSM_CRT_STR,
+	.crt_id = HSM_CRT_ID,
+};
+
+int pkcs11_get_uuid(lmp_options &opt)
+{
+	PKCS11_SLOT *slots{nullptr};
+	PKCS11_CTX *ctx{nullptr};
+	unsigned int nslots = 0;
+
+	if (opt.hsm_module.empty())
+		return 0;
+
+	ctx = PKCS11_CTX_new();
+	if (!ctx)
+		leave;
+
+	if (PKCS11_CTX_load(ctx, opt.hsm_module.c_str()))
+		leave;
+
+	if (PKCS11_enumerate_slots(ctx, &slots, &nslots))
+		leave;
+
+	/* UUID format is a requirement for HSM modules (mainly OP-TEE) */
+	std::regex UUID("("
+			"[a-f0-9]{8}-"
+			"[a-f0-9]{4}-"
+			"[a-f0-9]{4}-"
+			"[a-f0-9]{4}-"
+			"[a-f0-9]{12}"
+			")");
+	std::smatch match;
+
+	for (size_t i = 0; i < nslots && opt.uuid.empty(); i++) {
+		string slot_info = string(slots[i].description);
+
+		std::regex_search(slot_info, match, UUID);
+		if (match.size() > 0)
+			opt.uuid = match.str(1);
+	}
+
+	PKCS11_release_all_slots(ctx, slots, nslots);
+	PKCS11_CTX_unload(ctx);
+	PKCS11_CTX_free(ctx);
+
+	return 0;
+}
+
+/* Initialize HSM_TOKEN_STR (aktualizr token) */
+static int pkcs11_initialize(const lmp_options &opt)
+{
+	PKCS11_TOKEN *token = NULL;
+	PKCS11_SLOT *slots = NULL;
+	PKCS11_SLOT *slot = NULL;
+	PKCS11_CTX *ctx = NULL;
+	unsigned int nslots;
+	char label[32] = { };
+
+	memset(label, ' ', 32);
+
+	ctx = PKCS11_CTX_new();
+
+	if (PKCS11_CTX_load(ctx, opt.hsm_module.c_str()))
+		leave;
+
+	if (PKCS11_enumerate_slots(ctx, &slots, &nslots))
+		leave;
+
+	slot = PKCS11_find_token(ctx, slots, nslots);
+
+	while (slot && slot->token && slot->token->initialized)
+		slot = PKCS11_find_next_token(ctx, slots, nslots, slot);
+
+	if (!slot || !slot->token || slot->token->initialized)
+		leave;
+
+	/* We have an un-initialized token */
+	token = slot->token;
+
+	/* Remove the 'end of string' character from the label */
+	memcpy(label, HSM_TOKEN_STR, strlen(HSM_TOKEN_STR));
+
+	if (PKCS11_init_token(token, opt.hsm_so_pin.c_str(),
+			      (const char *)label))
+		leave;
+
+	if (PKCS11_open_session(slot, 1))
+		leave;
+
+	if (PKCS11_login(slot, 1, opt.hsm_so_pin.c_str()))
+		leave;
+
+	if (PKCS11_init_pin(token, opt.hsm_pin.c_str()))
+		leave;
+
+	if (PKCS11_logout(slot))
+		leave;
+
+	PKCS11_release_all_slots(ctx, slots, nslots);
+	PKCS11_CTX_unload(ctx);
+	PKCS11_CTX_free(ctx);
+
+	cout << "PKCS11 token " << HSM_TOKEN_STR << " initialized" << endl;
+
+	return 0;
+}
+
+/* Create an EC keypair in the HSM (not TPM) and generate a CSR */
+int pkcs11_create_csr(const lmp_options &opt, string &pkey, string &csr)
+{
+	PKCS11_SLOT *slots = NULL;
+	PKCS11_SLOT *slot = NULL;
+	PKCS11_CTX *ctx = NULL;
+	PKCS11_KEY *key = NULL;
+	EVP_PKEY *prv = NULL;
+	EVP_PKEY *pub = NULL;
+	unsigned int nslots = 0;
+	unsigned int n = 0;
+	PKCS11_EC_KGEN ec = {
+		.curve = "P-256",
+	};
+	PKCS11_KGEN_ATTRS attr = {
+		.type = EVP_PKEY_EC,
+		.token_label = hsm_cfg.token.c_str(),
+		.key_label = hsm_cfg.tls_lbl.c_str(),
+		.key_id = hsm_cfg.tls_id.c_str(),
+	};
+	bool init = false;
+
+	if (opt.hsm_module.empty())
+		leave;
+
+	attr.kgen.ec = &ec;
+again:
+	ctx = PKCS11_CTX_new();
+
+	if (PKCS11_CTX_load(ctx, opt.hsm_module.c_str()))
+		leave;
+
+	if (PKCS11_enumerate_slots(ctx, &slots, &nslots))
+		leave;
+
+	slot = PKCS11_find_token(ctx, slots, nslots);
+
+	while (slot && slot->token->label != hsm_cfg.token)
+		slot = PKCS11_find_next_token(ctx, slots, nslots, slot);
+
+	/* The  HSM_TOKEN_STR was not found, initialize it  */
+	if (!slot || slot->token->label != hsm_cfg.token) {
+		if (!init) {
+			PKCS11_release_all_slots(ctx, slots, nslots);
+			PKCS11_CTX_unload(ctx);
+			PKCS11_CTX_free(ctx);
+
+			if (pkcs11_initialize(opt))
+				leave;
+
+			init = true;
+			goto again;
+		}
+		cout << "PKCS11 token not found after initializing" << endl;
+		leave;
+	} else {
+		cout << "PKCS11 token " << HSM_TOKEN_STR << " found" << endl;
+	}
+
+	if (PKCS11_open_session(slot, 1))
+		leave;
+
+	if (PKCS11_login(slot, 0, opt.hsm_pin.c_str()))
+		leave;
+
+	if (PKCS11_generate_key(slot->token, &attr))
+		leave;
+
+	if (PKCS11_enumerate_public_keys(slot->token, &key, &n) || !n)
+		leave;
+
+	for ( ; !pub && key && n; key++, n--) {
+		if (key->label == hsm_cfg.tls_lbl)
+			pub = PKCS11_get_public_key(key);
+	}
+
+	if (!pub)
+		leave;
+
+	if (PKCS11_enumerate_keys(slot->token, &key, &n) || !n)
+		leave;
+
+	for ( ; !prv && key && n; key++, n--) {
+		if (key->label == hsm_cfg.tls_lbl)
+			prv = PKCS11_get_private_key(key);
+	}
+
+	if (!prv)
+		leave;
+
+	if (PKCS11_logout(slot))
+		leave;
+
+	/* Use OpenSSL to generate the request in the csr buffer */
+	if (openssl_gen_csr(opt, pub, prv, csr))
+		leave;
+
+	pkey = hsm_cfg.tls_id;
+
+	/* Free the keys */
+	EVP_PKEY_free(pub);
+	EVP_PKEY_free(prv);
+
+	/* Release context */
+	PKCS11_release_all_slots(ctx, slots, nslots);
+	PKCS11_CTX_unload(ctx);
+	PKCS11_CTX_free(ctx);
+
+	return 0;
+}
+
+/* Write a PEM cerficate in the PKCS#11 database (secure storage - ie RPMB ) */
+int pkcs11_store_cert(lmp_options &opt, X509 *cert)
+{
+	PKCS11_SLOT *slots = NULL;
+	PKCS11_SLOT *slot = NULL;
+	PKCS11_CTX *ctx = NULL;
+	unsigned int nslots = 0;
+
+	ctx = PKCS11_CTX_new();
+
+	if (PKCS11_CTX_load(ctx, opt.hsm_module.c_str()))
+		leave;
+
+	if (PKCS11_enumerate_slots(ctx, &slots, &nslots))
+		leave;
+
+	slot = PKCS11_find_token(ctx, slots, nslots);
+
+	while (slot && slot->token->label != hsm_cfg.token)
+		slot = PKCS11_find_next_token(ctx, slots, nslots, slot);
+
+	if (!slot || slot->token->label != hsm_cfg.token)
+		leave;
+
+	if (PKCS11_open_session(slot, 1))
+		leave;
+
+	if (PKCS11_login(slot, 0, opt.hsm_pin.c_str()))
+		leave;
+
+	if (PKCS11_store_certificate(slot->token, cert, (char *)HSM_CRT_STR,
+				     (unsigned char *)&hsm_cfg.crt_id,
+				     sizeof(hsm_cfg.crt_id), NULL))
+		leave;
+
+	if (PKCS11_logout(slot))
+		leave;
+
+	cout << "Certificate written to PKCS#11 secure storage" << endl;
+
+	PKCS11_release_all_slots(ctx, slots, nslots);
+	PKCS11_CTX_unload(ctx);
+	PKCS11_CTX_free(ctx);
+
+	return 0;
+}

--- a/src/pkcs11_stub.cpp
+++ b/src/pkcs11_stub.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Foundries.io
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <device_register.h>
+
+int pkcs11_create_csr(const lmp_options &options, string &key, string &csr)
+{
+	cout << "Executing PKCS11 stub " << endl;
+
+	return -1;
+}
+
+int pkcs11_store_cert(lmp_options &opt, X509 *cert)
+{
+	cout << "Executing PKCS11 stub " << endl;
+
+	return -1;
+}
+
+int pkcs11_get_uuid(lmp_options &opt)
+{
+	if (opt.hsm_module.empty())
+		return 0;
+
+	cout << "Executing PKCS11 stub " << endl;
+
+	return -1;
+}
+


### PR DESCRIPTION
Uses libp11 and the openssl API instead of the helper programs to access pkcs#11 and openssl.

Needs one fix to libp11 (for token initialization) and one missing feature (EC key generation, proposed upstream) plus a fix required to support TPM.


Co-developed-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>