### PR TITLE
options: toggle UUID validation

### DIFF
--- a/inc/device_register.h
+++ b/inc/device_register.h
@@ -91,6 +91,7 @@ struct lmp_options {
 	bool use_server;
 	bool production;
 	bool mlock;
+	bool vuuid;
 #if defined DOCKER_COMPOSE_APP
 	string apps;
 	string restorable_apps;


### PR DESCRIPTION
Some legacy products might have been registered with an invalid UUID. Allow them to continue registering by ignoring the UUID validation step.