### PR TITLE
pkcs11: remove existing PKCS#11 keys to avoid label conflicts

### DIFF
--- a/inc/curl.hpp
+++ b/inc/curl.hpp
@@ -110,7 +110,7 @@ public:
 		CURLcode res = curl_easy_perform(curl);
 		if (res != CURLE_OK) {
 			cerr << "Unable to post to " << _url << ": " << curl_easy_strerror(res) << endl;
-			exit(1);
+			return -1;
 		}
 
 		if (chunk != nullptr) {
@@ -121,7 +121,7 @@ public:
 		res = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
 		if (res != CURLE_OK) {
 			cerr << "Unable to get curl info: " << curl_easy_strerror(res) << endl;
-			exit(1);
+			return -1;
 		}
 		ParseResponse(body, resp);
 		return code;

--- a/inc/device_register.h
+++ b/inc/device_register.h
@@ -115,4 +115,5 @@ int pkcs11_create_csr(const lmp_options &options, string &key, string &csr);
 int pkcs11_store_cert(lmp_options &opt, X509 *cert);
 int pkcs11_get_uuid(lmp_options &options);
 int pkcs11_check_hsm(lmp_options &opt);
+int pkcs11_remove_keys(lmp_options &opt);
 #endif

--- a/inc/device_register.h
+++ b/inc/device_register.h
@@ -92,6 +92,7 @@ struct lmp_options {
 	bool production;
 	bool mlock;
 	bool vuuid;
+	bool force;
 #if defined DOCKER_COMPOSE_APP
 	string apps;
 	string restorable_apps;

--- a/inc/device_register.h
+++ b/inc/device_register.h
@@ -67,6 +67,22 @@
 #define SOTA_PEM "/client.pem"
 #define SOTA_SQL "/sql.db"
 
+
+#define leave_messages \
+   cerr << "Error !"<< endl; \
+   cerr << " Commit: " << GIT_COMMIT << endl; \
+   cerr << " File: " << __FILE__ << ", Func: " << __func__ \
+   << " Line: " << __LINE__ << endl;
+
+#define leave \
+({ leave_messages \
+   return -1; })
+
+#define leave_exit \
+({ leave_messages \
+   ret = -1; \
+   goto exit; })
+
 using boost::property_tree::ptree;
 using std::stringstream;
 using std::string;
@@ -102,7 +118,7 @@ struct lmp_options {
 typedef std::map<std::string, string> http_headers;
 
 int auth_register_device(http_headers &headers, ptree &device, ptree &resp);
-void auth_get_http_headers(lmp_options &opt, http_headers &headers);
+int auth_get_http_headers(lmp_options &opt, http_headers &headers);
 int auth_ping_server(void);
 
 int options_parse(int argc, char **argv, lmp_options &options);
@@ -115,5 +131,5 @@ int pkcs11_create_csr(const lmp_options &options, string &key, string &csr);
 int pkcs11_store_cert(lmp_options &opt, X509 *cert);
 int pkcs11_get_uuid(lmp_options &options);
 int pkcs11_check_hsm(lmp_options &opt);
-int pkcs11_remove_keys(lmp_options &opt);
+int pkcs11_cleanup(lmp_options &opt);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,8 +333,12 @@ int main(int argc, char **argv)
 	cout << "Registering device " << opt.name <<
 		" with factory " << opt.factory << endl;
 
-	if (auth_register_device(headers, info, resp))
+	if (auth_register_device(headers, info, resp)) {
+		/* Remove key pair created while */
+		if (!opt.hsm_module.empty())
+			pkcs11_remove_keys(opt);
 		exit(EXIT_FAILURE);
+	}
 
 	/* Store the login details */
 	if (populate_sota_dir(opt, resp, key))

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -6,13 +6,6 @@
 
 #include <device_register.h>
 
-#define leave \
-({ cerr << "Error !"<< endl; \
-   cerr << "  Commit : " << GIT_COMMIT << endl; \
-   cerr << "  File: openssl.cpp, Func: " << __func__ \
-   << " Line: " << __LINE__ << endl; \
-   return -1; })
-
 static int add_ext(STACK_OF(X509_EXTENSION)*sk, int nid, char *value)
 {
 	X509_EXTENSION *ex = X509V3_EXT_conf_nid(NULL, NULL, nid, value);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -82,6 +82,9 @@ namespace po = boost::program_options;
 #define HSM_PIN_HELP \
 "The PKCS#11 pin - HSM only."
 
+#define FORCE_HELP \
+"Force registration, removing data from previous execution."
+
 static void get_factory_tags_info(const string os_release, string &factory,
 				  string &fsrc, string &tag, string &tsrc)
 {
@@ -151,6 +154,7 @@ static void set_default_options(lmp_options &opt, string factory, string tags,
 	OPT_STR("name,n", opt.name, NAME_HELP)
 	OPT_DEF_STR("api-token-header,H",
 		    opt.api_token_header, "OSF-TOKEN",API_TOKEN_HDR_HELP)
+	OPT_DEF_BOOL("force", opt.force, false, FORCE_HELP)
 
 #if defined DOCKER_COMPOSE_APP
 	OPT_STR("apps,a", opt.apps, APPS_HELP)

--- a/src/pkcs11_stub.cpp
+++ b/src/pkcs11_stub.cpp
@@ -36,3 +36,10 @@ int pkcs11_check_hsm(lmp_options &opt)
 
 	return -1;
 }
+
+int pkcs11_remove_keys(lmp_options &opt)
+{
+	cout << "Executing PKCS11 stub " << endl;
+
+	return -1;
+}

--- a/src/pkcs11_stub.cpp
+++ b/src/pkcs11_stub.cpp
@@ -37,7 +37,7 @@ int pkcs11_check_hsm(lmp_options &opt)
 	return -1;
 }
 
-int pkcs11_remove_keys(lmp_options &opt)
+int pkcs11_cleanup(lmp_options &opt)
 {
 	cout << "Executing PKCS11 stub " << endl;
 


### PR DESCRIPTION
The current implementation allows multiple key pairs to be stored in the HSM using the same "tls" label, which leads to certificate errors inside aklite. Even a previous incomplete lmp-device-register execution might leave these keys behind.

This commit makes sure there are no other stored keys using the same label before creating a new key pair during the registration process.