### PR TITLE
pkcs11: make code compatible with libp11 0.4.16

### DIFF
--- a/inc/device_register.h
+++ b/inc/device_register.h
@@ -27,6 +27,7 @@
 #include <openssl/err.h>
 #include <openssl/buffer.h>
 
+#include <boost/algorithm/hex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/beast/core/detail/base64.hpp>
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
Update the pkcs11 keygen logic to reflect the changes done as part of the upstream libp11 0.4.16 release.