### PR TITLE
CMakeLists.txt: Boost.System is now header-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_definitions('-Wall')
 
 # find all required libraries
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost COMPONENTS filesystem iostreams program_options system REQUIRED)
+find_package(Boost COMPONENTS filesystem iostreams program_options REQUIRED)
 find_package(CURL REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(OpenSSL 3.0.0 REQUIRED)


### PR DESCRIPTION
In Boost 1.89.0 release, Boost.System stub library has been removed.

Ref: https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3